### PR TITLE
Add commands and canister id env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ npm run erase-replica
 ### 4. Deploy your canisters to the replica
 Local:
 ```bash
-dfx deploy --argument "( principal\"$(dfx identity get-principal)\" )" DeVinci_backend
-dfx deploy
+dfx deploy --argument "( principal\"$(dfx identity get-principal)\" )" DeVinci_backend --network local
+dfx deploy internet_identity --network local
+dfx deploy DeVinci_frontend --network local
 ```
 Alternative: Run a local vite UI (note that this had issues communicating to the backend canister for some setups in the past)
 ```bash

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,7 @@ const canisterDefinitions = Object.entries(canisterIds).reduce(
   (acc, [key, val]) => ({
     ...acc,
     [`process.env.${key.toUpperCase()}_CANISTER_ID`]: JSON.stringify(val[networkName]),
+    [`process.env.CANISTER_ID_${key.toUpperCase()}`]: JSON.stringify(val[networkName]),
   }),
   {},
 );


### PR DESCRIPTION
The following local login options worked:
run (copy from Readme)
dfx deploy --argument "( principal\"$(dfx identity get-principal)\" )" DeVinci_backend --network local
dfx deploy internet_identity --network local
dfx deploy DeVinci_frontend --network local

the last command prints something like
http://be2us-64aaa-aaaaa-qaabq-cai.localhost:4943/

Internet Identity, NFid with Google and Bitfinity worked as login options