### PR TITLE
Upload to vector db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,9 +1525,12 @@
       }
     },
     "@mlc-ai/web-llm": {
-      "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.33.tgz",
-      "integrity": "sha512-3sWAoP8xXN0xgTgTTJks7eIGRN3SZfHK0iKptdYMIrVELbcIwVA7lID/w/BqSo1K1Ia+zZu7nGRJNy9gRZwMpg=="
+      "version": "0.2.40",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.40.tgz",
+      "integrity": "sha512-ibY1zRDe9IyxUicLsox7NZx7BYBJqT6E8jk0jSWOzit6HdaAEMqvL+B042Enq8egA+aJ2lERJhaccnWM+HdXyw==",
+      "requires": {
+        "loglevel": "^1.9.1"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3988,6 +3991,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true
+    },
+    "loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="
     },
     "long": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@dfinity/authentication": "^0.14.2",
     "@dfinity/candid": "0.15.1",
     "@dfinity/principal": "0.15.1",
-    "@mlc-ai/web-llm": "0.2.33",
+    "@mlc-ai/web-llm": "0.2.40",
     "@tensorflow-models/universal-sentence-encoder": "1.3.3",
     "@tensorflow/tfjs-backend-webgl": "4.15.0",
     "@tensorflow/tfjs-converter": "4.15.0",

--- a/src/DeVinci_backend/Types.mo
+++ b/src/DeVinci_backend/Types.mo
@@ -155,7 +155,7 @@ module {
   };
 
   public type MemoryVectorMetadata = {
-    id: Text;
+    id: Int;
   };
 
   public type MemoryVector = {
@@ -167,6 +167,8 @@ module {
   public type MemoryVectorsStoredResult = Result<Bool, ApiError>;
 
   public type MemoryVectorsResult = Result<[MemoryVector], ApiError>;
+
+  public type MemoryVectorsCheckResult = Result<Bool, ApiError>;
 
   public type SignUpFormInput = {
     emailAddress: Text; // provided by user on signup

--- a/src/DeVinci_backend/Types.mo
+++ b/src/DeVinci_backend/Types.mo
@@ -154,6 +154,20 @@ module {
     updatedSpaceData: ?Text;
   };
 
+  public type MemoryVectorMetadata = {
+    id: Text;
+  };
+
+  public type MemoryVector = {
+    content: Text;
+    embedding: [Float];
+    metadata: MemoryVectorMetadata;
+  };
+
+  public type MemoryVectorsStoredResult = Result<Bool, ApiError>;
+
+  public type MemoryVectorsResult = Result<[MemoryVector], ApiError>;
+
   public type SignUpFormInput = {
     emailAddress: Text; // provided by user on signup
     pageSubmittedFrom: Text; // capture for analytics

--- a/src/DeVinci_backend/main.mo
+++ b/src/DeVinci_backend/main.mo
@@ -385,6 +385,7 @@ shared actor class DeVinciBackend(custodian: Principal) = Self {
     if (Principal.isAnonymous(caller)) {
       return #Err(#Unauthorized);
 		};
+    
     switch (getUserMemoryVectors(caller)) {
       case (null) { return #Err(#Unauthorized); };
       case (?memoryVectors) { return #Ok(memoryVectors); };

--- a/src/DeVinci_backend/main.mo
+++ b/src/DeVinci_backend/main.mo
@@ -392,6 +392,18 @@ shared actor class DeVinciBackend(custodian: Principal) = Self {
     };   
   };
 
+  public shared query ({caller}) func check_caller_has_memory_vectors_entry() : async Types.MemoryVectorsCheckResult {
+    // don't allow anonymous Principal
+    if (Principal.isAnonymous(caller)) {
+      return #Err(#Unauthorized);
+		};
+    
+    switch (getUserMemoryVectors(caller)) {
+      case (null) { return #Err(#Unauthorized); };
+      case (?memoryVectors) { return #Ok(true); };
+    };   
+  };
+
 // Email Signups from Website
   stable var emailSubscribersStorageStable : [(Text, Types.EmailSubscriber)] = [];
   var emailSubscribersStorage : HashMap.HashMap<Text, Types.EmailSubscriber> = HashMap.HashMap(0, Text.equal, Text.hash);

--- a/src/DeVinci_frontend/components/BitfinityButton.svelte
+++ b/src/DeVinci_frontend/components/BitfinityButton.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { store } from "../store";
 
   import spinner from "../assets/loading.gif";

--- a/src/DeVinci_frontend/components/ChatInterface.svelte
+++ b/src/DeVinci_frontend/components/ChatInterface.svelte
@@ -5,7 +5,12 @@
   import ChatBox from "./ChatBox.svelte";
   import ChatHistory from "./ChatHistory.svelte";
   import { store } from "../store";
-  import { getSearchVectorDbTool, storeEmbeddings, loadExistingVectorStore, checkUserHasKnowledgeBase } from "../helpers/vector_database";
+  import {
+    getSearchVectorDbTool,
+    //storeEmbeddings,
+    //loadExistingVectorStore,
+    //checkUserHasKnowledgeBase
+  } from "../helpers/vector_database";
   import spinner from "../assets/loading.gif";
 
   const workerPath = './worker.ts';
@@ -110,9 +115,13 @@
   let pathToUploadedPdf = '';
   let initiatedKnowledgeDatabase = false;
   let loadingKnowledgeDatabase = false;
-  let persistingCurrentEmbeddings = false;
-  let userHasExistingKnowledgeBase = false;
   let useKnowledgeBase = false;
+  //let persistingCurrentEmbeddings = false;
+  //let userHasExistingKnowledgeBase = false;
+
+  function handleUseKnowledgeBaseToggle() {
+    useKnowledgeBase = !useKnowledgeBase;
+  };
 
   async function uploadPdfToVectorDatabase() {
     const fileInput = document.getElementById('pdf-upload') as HTMLInputElement;
@@ -128,6 +137,17 @@
     } else {
       alert("Please select a PDF file.");
     };
+  };
+
+  // functionality to retrieve and store user's knowledge base
+  /* async function checkUserKnowledgeBase() {
+    console.log("DEBUG checkUserKnowledgeBase");
+    if(!$store.isAuthed){
+      userHasExistingKnowledgeBase = false;
+    };
+    let knowledgeBaseExists = await checkUserHasKnowledgeBase();
+    console.log("DEBUG checkUserKnowledgeBase knowledgeBaseExists ", knowledgeBaseExists);
+    userHasExistingKnowledgeBase = knowledgeBaseExists;
   };
 
   async function getPreviousEmbeddings() {
@@ -150,21 +170,7 @@
     await storeEmbeddings();
     persistingCurrentEmbeddings = false;
     alert("Your Knowledge Base Was Stored!");
-  };
-
-  async function checkUserKnowledgeBase() {
-    console.log("DEBUG checkUserKnowledgeBase");
-    if(!$store.isAuthed){
-      userHasExistingKnowledgeBase = false;
-    };
-    let knowledgeBaseExists = await checkUserHasKnowledgeBase();
-    console.log("DEBUG checkUserKnowledgeBase knowledgeBaseExists ", knowledgeBaseExists);
-    userHasExistingKnowledgeBase = knowledgeBaseExists;
-  };
-
-  function handleUseKnowledgeBaseToggle() {
-    useKnowledgeBase = !useKnowledgeBase;
-  };
+  }; */
 
 // User can select between chats (global variable is kept)
   async function showNewChat() {
@@ -204,7 +210,7 @@
       {:else if initiatedKnowledgeDatabase}
         <p class="font-semibold text-gray-900 dark:text-gray-600">Success, the local Knowledge Base is ready! Your PDF's content will now be used by the AI in its responses.</p>
         <p class="text-gray-900 dark:text-gray-600">You can also load a different PDF into the local Knowledge Base on your device. The AI will include that PDF's content in its answers to your prompts then.</p>
-        {#if $store.isAuthed}
+        <!-- {#if $store.isAuthed}
           <Button id="storeEmbeddingsButton"
             class="bg-slate-100 text-slate-900 hover:bg-slate-200 hover:text-slate-900"
             on:click={persistCurrentEmbeddings}>Store Knowledge Base</Button>
@@ -214,11 +220,11 @@
           {:else}
             <p class="text-gray-900 dark:text-gray-600">You may store the local Knowledge Base created from your PDF's content. You can then also use it when you return next time.</p>            
           {/if}
-        {/if}
+        {/if} -->
       {:else}
         <p class="text-gray-900 dark:text-gray-600">This loads your PDF into a local Knowledge Base on your device such that the AI can include the PDF's content in its answers to your prompts in real-time.</p>
       {/if}
-      {#if $store.isAuthed}
+      <!-- {#if $store.isAuthed}
         <p hidden>{checkUserKnowledgeBase()}</p>
         {#if userHasExistingKnowledgeBase}
           <Button id="retrieveEmbeddingsButton"
@@ -226,7 +232,7 @@
             on:click={getPreviousEmbeddings}>Load Previous Knowledge Base</Button>
           <p class="text-gray-900 dark:text-gray-600">Instead, you may also load the Knowledge Base you stored last time. The AI can then use it like before (with the contents of the PDF you uploaded back then).</p>
         {/if}
-      {/if}
+      {/if} -->
     </div>
   {:else}
     {#if chatModelDownloadInProgress}

--- a/src/DeVinci_frontend/components/ChatInterface.svelte
+++ b/src/DeVinci_frontend/components/ChatInterface.svelte
@@ -5,7 +5,7 @@
   import ChatBox from "./ChatBox.svelte";
   import ChatHistory from "./ChatHistory.svelte";
   import { store } from "../store";
-  import { getSearchVectorDbTool, storeEmbeddings, retrieveEmbeddings } from "../helpers/vector_database";
+  import { getSearchVectorDbTool, storeEmbeddings, loadExistingVectorStore } from "../helpers/vector_database";
   import spinner from "../assets/loading.gif";
 
   const workerPath = './worker.ts';
@@ -132,7 +132,7 @@
       return;
     };
     loadingKnowledgeDatabase = true;
-    await retrieveEmbeddings();
+    await loadExistingVectorStore();
     initiatedKnowledgeDatabase = true;
     loadingKnowledgeDatabase = false;
     alert("Your Knowledge Base Was Loaded!");
@@ -175,7 +175,10 @@
       <Button class="bg-slate-100 text-slate-900 hover:bg-slate-200 hover:text-slate-900" on:click={() => document.getElementById('pdf-upload').click()}>
         Upload PDF
       </Button>
-      {#if initiatedKnowledgeDatabase}
+      {#if loadingKnowledgeDatabase}
+        <p class="font-semibold text-gray-900 dark:text-gray-600">Loading your content into the local Knowledge Base for you...</p>
+        <img class="h-12 mx-auto p-1 block" src={spinner} alt="loading animation" />
+      {:else if initiatedKnowledgeDatabase}
         <p class="font-semibold text-gray-900 dark:text-gray-600">Success, the local Knowledge Base is ready! Your PDF's content will now be used by the AI in its responses.</p>
         <p class="text-gray-900 dark:text-gray-600">You can also load a different PDF into the local Knowledge Base on your device. The AI will include that PDF's content in its answers to your prompts then.</p>
         {#if $store.isAuthed}
@@ -189,9 +192,6 @@
             <p class="text-gray-900 dark:text-gray-600">You may store the local Knowledge Base created from your PDF's content. You can then also use it when you return next time.</p>            
           {/if}
         {/if}
-      {:else if loadingKnowledgeDatabase}
-        <p class="font-semibold text-gray-900 dark:text-gray-600">Loading your content into the local Knowledge Base for you...</p>
-        <img class="h-12 mx-auto p-1 block" src={spinner} alt="loading animation" />
       {:else}
         <p class="text-gray-900 dark:text-gray-600">This loads your PDF into a local Knowledge Base on your device such that the AI can include the PDF's content in its answers to your prompts in real-time.</p>
       {/if}

--- a/src/DeVinci_frontend/components/ChatInterface.svelte
+++ b/src/DeVinci_frontend/components/ChatInterface.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import * as webllm from "@mlc-ai/web-llm";
-  import { chatModelGlobal, chatModelDownloadedGlobal, activeChatGlobal, selectedAiModelId } from "../store";
+  import { onMount } from 'svelte';
+  import { store, chatModelGlobal, chatModelDownloadedGlobal, activeChatGlobal, selectedAiModelId } from "../store";
   import Button from "./Button.svelte";
   import ChatBox from "./ChatBox.svelte";
   import ChatHistory from "./ChatHistory.svelte";
-  import { store } from "../store";
+  import InstallToastNotification from './InstallToastNotification.svelte';
   import {
     getSearchVectorDbTool,
     //storeEmbeddings,
@@ -14,6 +15,17 @@
   import spinner from "../assets/loading.gif";
 
   const workerPath = './worker.ts';
+
+  let showToast = false;
+
+  onMount(() => {
+    showToast = true; // Show toast on load
+
+    // Automatically hide the toast
+    setTimeout(() => {
+      showToast = false;
+    }, 8000);
+  });
   
 
   let chatModelDownloadInProgress = false;
@@ -244,9 +256,14 @@
         class="bg-slate-100 text-slate-900 hover:bg-slate-200 hover:text-slate-900"
         on:click={loadChatModel}>Initialize</Button>
     {/if}
+    <p>Did you know? You can also install the DeVinci app on your device. And once you've downloaded the AI Assistant, you can even chat with it in the installed app offline!</p>
     <p>Note: AI assistants are pretty huge and require quite some computational resources. 
       As DeVinci runs on your device (via the browser), whether and how fast it may run depend on the device's hardware. If a given model doesn't work, you can try a smaller one from the selection under Settings and see if the device can support it.</p>
     <p>For the best possible experience, we recommend running as few other programs and browser tabs as possible besides DeVinci as those can limit the computational resources available for DeVinci.</p>
   {/if}
   <!-- <p id="debug-label"> </p>  Debug -->
 </section>
+
+{#if showToast}
+  <InstallToastNotification />
+{/if}

--- a/src/DeVinci_frontend/components/ChatInterface.svelte
+++ b/src/DeVinci_frontend/components/ChatInterface.svelte
@@ -304,7 +304,7 @@
     {/key}
     <!-- TODO: refactor into own RAG component -->
     <!-- TODO: does not work properly on mobile -->
-    {#if !deviceType}
+    {#if deviceType === 'desktop'}
       <div class="space-y-2">
         <h3 class="font-semibold text-gray-900 dark:text-gray-600">Chat with a PDF</h3>
         <div>

--- a/src/DeVinci_frontend/components/ChatInterface.svelte
+++ b/src/DeVinci_frontend/components/ChatInterface.svelte
@@ -18,7 +18,7 @@
   let vectorDbSearchTool;
 
   // Debug Android
-  //let debugOutput = "";
+  let debugOutput = "";
 
   function setLabel(id: string, text: string) {
     const label = document.getElementById(id);
@@ -29,8 +29,8 @@
   }
 
   async function loadChatModel() {
-    /* debugOutput += "###in loadChatModel###";
-    setLabel("debug-label", debugOutput); */
+    debugOutput += "###in loadChatModel###";
+    setLabel("debug-label", debugOutput);
     if (chatModelDownloadInProgress) {
       return;
     };
@@ -48,14 +48,14 @@
           {type: 'module'}
         )); */
         //console.log("Using webllm");
-        $chatModelGlobal = new webllm.Engine();
+        $chatModelGlobal = new webllm.MLCEngine();
       } catch (error) {
         console.error("Error loading web worker: ", error);
-        $chatModelGlobal = new webllm.Engine();
+        $chatModelGlobal = new webllm.MLCEngine();
       }      
     } else {
       //console.log("Using webllm");
-      $chatModelGlobal = new webllm.Engine();
+      $chatModelGlobal = new webllm.MLCEngine();
     };
 
     const initProgressCallback = (report) => {
@@ -231,5 +231,5 @@
       As DeVinci runs on your device (via the browser), whether and how fast it may run depend on the device's hardware. If a given model doesn't work, you can try a smaller one from the selection under Settings and see if the device can support it.</p>
     <p>For the best possible experience, we recommend running as few other programs and browser tabs as possible besides DeVinci as those can limit the computational resources available for DeVinci.</p>
   {/if}
-  <!-- <p id="debug-label"> </p>  Debug -->
+  <p id="debug-label"> </p>  Debug
 </section>

--- a/src/DeVinci_frontend/components/InstallToastNotification.svelte
+++ b/src/DeVinci_frontend/components/InstallToastNotification.svelte
@@ -1,0 +1,79 @@
+<script>
+  import { onMount } from 'svelte';
+
+  let deferredPrompt;
+  let showToast = false;
+
+  onMount(() => {
+    window.addEventListener('beforeinstallprompt', (e) => {
+      // Prevent the mini-infobar from appearing on mobile
+      e.preventDefault();
+      // Stash the event so it can be triggered later.
+      deferredPrompt = e;
+      // Update UI notify the user they can install the PWA
+      showToast = true;
+    });
+
+    window.addEventListener('appinstalled', () => {
+      // Hide the app-provided install promotion
+      showToast = false;
+      console.log('PWA was installed');
+    });
+  });
+
+  async function installPWA() {
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      console.log(`User response to the install prompt: ${outcome}`);
+      if (outcome === 'accepted') {
+        console.log('User accepted the A2HS prompt');
+      } else {
+        console.log('User dismissed the A2HS prompt');
+      }
+      deferredPrompt = null;
+    }
+  }
+</script>
+
+{#if showToast}
+  <div class="toast">
+    <p>This app can be installed and used offline!</p>
+    <button on:click={installPWA}>Install</button>
+  </div>
+{/if}
+
+<style>
+  .toast {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 20px;
+    background-color: #323232;
+    color: white;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    z-index: 1000;
+  }
+
+  .toast p {
+    margin: 0;
+    padding-right: 10px;
+  }
+
+  button {
+    border: none;
+    padding: 10px 15px;
+    background-color: #f0f0f0;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+
+  button:hover {
+    background-color: #e8e8e8;
+  }
+</style>

--- a/src/DeVinci_frontend/components/StoicButton.svelte
+++ b/src/DeVinci_frontend/components/StoicButton.svelte
@@ -1,7 +1,7 @@
 <script>
-    import { onMount } from "svelte";
-    import { StoicIdentity } from "ic-stoic-identity";
-    import { store } from "../store";
+    //import { onMount } from "svelte";
+    //import { StoicIdentity } from "ic-stoic-identity";
+    //import { store } from "../store";
 
     import Button from "./Button.svelte";
     import spinner from "../assets/loading.gif";

--- a/src/DeVinci_frontend/helpers/ai_model_helpers.js
+++ b/src/DeVinci_frontend/helpers/ai_model_helpers.js
@@ -1,14 +1,30 @@
 const availableAiModels = [
   {
-    id: 'gemma-2b-it-q4f32_1',
+    id: 'gemma-2b-it-q4f32_1-MLC',
     name: 'Gemma',
-    size: 'Smaller',
+    size: 'Small',
     numberOfParameters: '2 billion',
     performance: 'Good',
     default: true
   },
   {
-    id: 'Llama-3-8B-Instruct-q4f32_1',
+    id: 'Hermes-2-Pro-Llama-3-8B-q4f32_1-MLC',
+    name: 'Hermes 2 Pro Llama3',
+    size: 'Large',
+    numberOfParameters: '8B billion',
+    performance: 'Super Good',
+    default: false
+  },
+  { //requires shader-f16
+    id: 'Hermes-2-Pro-Mistral-7B-q4f16_1-MLC',
+    name: 'Hermes 2 Pro Mistral',
+    size: 'Large',
+    numberOfParameters: '7B billion',
+    performance: 'Super Good',
+    default: false
+  },
+  {
+    id: 'Llama-3-8B-Instruct-q4f32_1-MLC',
     name: 'Llama3 8B',
     size: 'Large',
     numberOfParameters: '8 billion',
@@ -16,23 +32,39 @@ const availableAiModels = [
     default: false
   },
   {
-    id: 'TinyLlama-1.1B-Chat-v0.4-q0f32',
+    id: 'Phi-3-mini-4k-instruct-q4f32_1-MLC',
+    name: 'Phi3',
+    size: 'Medium',
+    numberOfParameters: '3.8 billion',
+    performance: 'Very Good',
+    default: false
+  },
+  { //requires shader-f16
+    id: 'TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC',
     name: 'TinyLlama',
-    size: 'Small',
+    size: 'Very Small',
     numberOfParameters: '1.1 billion',
     performance: 'Alright',
     default: false
   },
-  { //requires shader-f16
-    id: 'Mistral-7B-Instruct-v0.2-q4f16_1',
-    name: 'Mistral',
-    size: 'Large',
-    numberOfParameters: '7 billion',
-    performance: 'Very Good',
+  {
+    id: 'Qwen1.5-1.8B-Chat-q4f32_1-MLC',
+    name: 'Qwen 1.5',
+    size: 'Small',
+    numberOfParameters: '1.8 billion',
+    performance: 'Good for Chinese',
     default: false
   },
   {
-    id: 'RedPajama-INCITE-Chat-3B-v1-q4f32_1',
+    id: 'stablelm-2-zephyr-1_6b-q4f32_1-MLC',
+    name: 'Stable LM 2',
+    size: 'Small',
+    numberOfParameters: '1.6 billion',
+    performance: 'Good',
+    default: false
+  },
+  { //requires shader-f16
+    id: 'RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC',
     name: 'Red Pajama',
     size: 'Medium',
     numberOfParameters: '3 billion',
@@ -40,15 +72,15 @@ const availableAiModels = [
     default: false
   },
   { //requires shader-f16
-    id: 'Llama-2-13b-chat-hf-q4f16_1',
-    name: 'Llama2 13B',
-    size: 'Very Large',
-    numberOfParameters: '13 billion',
-    performance: 'Super Good',
+    id: 'Mistral-7B-Instruct-v0.2-q4f16_1-MLC',
+    name: 'Mistral',
+    size: 'Large',
+    numberOfParameters: '7 billion',
+    performance: 'Very Good',
     default: false
   },
   { //requires shader-f16
-    id: 'Llama-3-70B-Instruct-q3f16_1',
+    id: 'Llama-3-70B-Instruct-q3f16_1-MLC',
     name: 'Llama3 70B',
     size: 'Gigantic',
     numberOfParameters: '70 billion',
@@ -56,11 +88,11 @@ const availableAiModels = [
     default: false
   },
   { //requires shader-f16
-    id: 'Llama-2-70b-chat-hf-q4f16_1',
-    name: 'Llama2 70B',
-    size: 'Gigantic',
-    numberOfParameters: '70 billion',
-    performance: 'Great',
+    id: 'WizardMath-7B-V1.1-q4f16_1-MLC',
+    name: 'WizardMath',
+    size: 'Large',
+    numberOfParameters: '7 billion',
+    performance: 'Great for Math',
     default: false
   },
   // Android WebGPU models
@@ -74,16 +106,25 @@ const availableAiModels = [
     android: true
   },
   {
-    id: 'Phi2-q4f32_1-1k',
-    name: 'Phi',
-    size: 'Smaller',
-    numberOfParameters: '2 billion',
-    performance: 'Good',
-    default: true,
+    id: 'Phi-3-mini-4k-instruct-q4f32_1-MLC-1k',
+    name: 'Phi3',
+    size: 'Medium',
+    numberOfParameters: '3.8 billion',
+    performance: 'Very Good',
+    default: false,
     android: true
   },
   {
-    id: 'Llama-3-8B-Instruct-q4f32_1-1k',
+    id: 'stablelm-2-zephyr-1_6b-q4f32_1-MLC-1k',
+    name: 'Stable LM 2',
+    size: 'Smaller',
+    numberOfParameters: '1.6 billion',
+    performance: 'Good',
+    default: false,
+    android: true
+  },
+  {
+    id: 'Llama-3-8B-Instruct-q4f32_1-MLC-1k',
     name: 'Llama3 8B',
     size: 'Large',
     numberOfParameters: '8 billion',
@@ -91,8 +132,26 @@ const availableAiModels = [
     default: false,
     android: true
   },
-  /* {
-    id: 'gemma-2b-it-q4f32_1-1k',
+  {
+    id: 'Qwen1.5-1.8B-Chat-q4f32_1-MLC-1k',
+    name: 'Qwen 1.5',
+    size: 'Smaller',
+    numberOfParameters: '1.8 billion',
+    performance: 'Good for Chinese',
+    default: false,
+    android: true
+  },
+  {
+    id: 'Phi2-q4f32_1-1k',
+    name: 'Phi2',
+    size: 'Smaller',
+    numberOfParameters: '2 billion',
+    performance: 'Good',
+    default: true,
+    android: true
+  },
+  {
+    id: 'gemma-2b-it-q4f32_1-MLC-1k',
     name: 'Gemma',
     size: 'Smaller',
     numberOfParameters: '2 billion',
@@ -100,8 +159,8 @@ const availableAiModels = [
     default: false,
     android: true
   },
-  {
-    id: 'TinyLlama-1.1B-Chat-v0.4-q4f32_1-1k',
+  { //requires shader-f16
+    id: 'TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC-1k',
     name: 'TinyLlama',
     size: 'Small',
     numberOfParameters: '1.1 billion',
@@ -109,24 +168,6 @@ const availableAiModels = [
     default: false,
     android: true
   },
-  {
-    id: 'Phi1.5-q4f32_1-1k',
-    name: 'Phi',
-    size: 'Small',
-    numberOfParameters: '1.5 billion',
-    performance: 'Alright',
-    default: false,
-    android: true
-  },
-  { //requires shader-f16
-    id: 'Llama-2-7b-chat-hf-q4f16_1-1k',
-    name: 'Llama2 7b',
-    size: 'Large',
-    numberOfParameters: '7 billion',
-    performance: 'Very Good',
-    default: false,
-    android: true
-  }, */
 ];
 
 export const getAvailableAiModels = (isAndroid = false) => {

--- a/src/DeVinci_frontend/helpers/ai_model_helpers.js
+++ b/src/DeVinci_frontend/helpers/ai_model_helpers.js
@@ -95,9 +95,18 @@ const availableAiModels = [
     performance: 'Great for Math',
     default: false
   },
-  // Android WebGPU models
+// Android WebGPU models
   {
-    id: 'RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k',
+    id: 'phi-2-q4f32_1-MLC-1k',
+    name: 'Phi2',
+    size: 'Smaller',
+    numberOfParameters: '2 billion',
+    performance: 'Good',
+    default: true,
+    android: true
+  },
+  {
+    id: 'RedPajama-INCITE-Chat-3B-v1-q4f32_1-MLC-1k',
     name: 'Red Pajama',
     size: 'Medium',
     numberOfParameters: '3 billion',
@@ -115,20 +124,29 @@ const availableAiModels = [
     android: true
   },
   {
-    id: 'stablelm-2-zephyr-1_6b-q4f32_1-MLC-1k',
-    name: 'Stable LM 2',
-    size: 'Smaller',
-    numberOfParameters: '1.6 billion',
-    performance: 'Good',
-    default: false,
-    android: true
-  },
-  {
     id: 'Llama-3-8B-Instruct-q4f32_1-MLC-1k',
     name: 'Llama3 8B',
     size: 'Large',
     numberOfParameters: '8 billion',
     performance: 'Super Good',
+    default: false,
+    android: true
+  },
+  {
+    id: 'TinyLlama-1.1B-Chat-v0.4-q4f32_1-MLC-1k',
+    name: 'TinyLlama',
+    size: 'Small',
+    numberOfParameters: '1.1 billion',
+    performance: 'Alright',
+    default: false,
+    android: true
+  },
+  /* {
+    id: 'gemma-2b-it-q4f32_1-MLC-1k',
+    name: 'Gemma',
+    size: 'Smaller',
+    numberOfParameters: '2 billion',
+    performance: 'Good',
     default: false,
     android: true
   },
@@ -142,32 +160,14 @@ const availableAiModels = [
     android: true
   },
   {
-    id: 'Phi2-q4f32_1-1k',
-    name: 'Phi2',
+    id: 'stablelm-2-zephyr-1_6b-q4f32_1-MLC-1k',
+    name: 'Stable LM 2',
     size: 'Smaller',
-    numberOfParameters: '2 billion',
-    performance: 'Good',
-    default: true,
-    android: true
-  },
-  {
-    id: 'gemma-2b-it-q4f32_1-MLC-1k',
-    name: 'Gemma',
-    size: 'Smaller',
-    numberOfParameters: '2 billion',
+    numberOfParameters: '1.6 billion',
     performance: 'Good',
     default: false,
     android: true
-  },
-  { //requires shader-f16
-    id: 'TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC-1k',
-    name: 'TinyLlama',
-    size: 'Small',
-    numberOfParameters: '1.1 billion',
-    performance: 'Alright',
-    default: false,
-    android: true
-  },
+  }, */
 ];
 
 export const getAvailableAiModels = (isAndroid = false) => {

--- a/src/DeVinci_frontend/helpers/ai_model_helpers.js
+++ b/src/DeVinci_frontend/helpers/ai_model_helpers.js
@@ -132,15 +132,6 @@ const availableAiModels = [
     default: false,
     android: true
   },
-  {
-    id: 'TinyLlama-1.1B-Chat-v0.4-q4f32_1-MLC-1k',
-    name: 'TinyLlama',
-    size: 'Small',
-    numberOfParameters: '1.1 billion',
-    performance: 'Alright',
-    default: false,
-    android: true
-  },
   /* {
     id: 'gemma-2b-it-q4f32_1-MLC-1k',
     name: 'Gemma',
@@ -165,6 +156,15 @@ const availableAiModels = [
     size: 'Smaller',
     numberOfParameters: '1.6 billion',
     performance: 'Good',
+    default: false,
+    android: true
+  },
+  {
+    id: 'TinyLlama-1.1B-Chat-v0.4-q4f32_1-MLC-1k',
+    name: 'TinyLlama',
+    size: 'Small',
+    numberOfParameters: '1.1 billion',
+    performance: 'Alright',
     default: false,
     android: true
   }, */

--- a/src/DeVinci_frontend/helpers/vector_database.ts
+++ b/src/DeVinci_frontend/helpers/vector_database.ts
@@ -132,11 +132,13 @@ const getDataEntries = async (pathToUploadedPdf) => {
 };
 
 export const storeEmbeddings = async () => {
+  console.log("Debug storeEmbeddings ");
   if (!vectorStoreState) {
     return;
   };
   try {
     const memVecs = vectorStoreState.memoryVectors;
+    console.log("Debug storeEmbeddings memVecs ", memVecs);
     try {
       const storeMemoryVectorsResponse = await storeState.backendActor.store_user_chats_memory_vectors(memVecs);
       console.log("Debug storeEmbeddings storeMemoryVectorsResponse ", storeMemoryVectorsResponse);
@@ -171,14 +173,16 @@ const retrieveEmbeddings = async () => {
 };
 
 export const loadExistingVectorStore = async () => {
+  console.log("Debug loadExistingVectorStore ");
   try {
     let retrievedMemVecs = await retrieveEmbeddings();
+    console.log("Debug loadExistingVectorStore retrievedMemVecs ", retrievedMemVecs);
     try {
       const start = performance.now() / 1000;
 
-      const textsToEmbed = [];
+      const textsToEmbed = ["valueToInitialize"];
 
-      const metadata = [];
+      const metadata = [{ id: 0 }];
 
       const embeddings = new TensorFlowEmbeddings();
 
@@ -187,7 +191,13 @@ export const loadExistingVectorStore = async () => {
         metadata,
         embeddings,
       );
-      
+      console.log("Debug loadExistingVectorStore vectorStoreState ", vectorStoreState);
+      console.log("Debug loadExistingVectorStore vectorStoreState.memoryVectors ", vectorStoreState.memoryVectors);
+
+      vectorStoreState.memoryVectors = retrievedMemVecs;
+
+      console.log("Debug loadExistingVectorStore vectorStoreState.memoryVectors after ", vectorStoreState.memoryVectors);
+
       vectorStore.set(vectorStoreState);
 
       const end = performance.now() / 1000;
@@ -198,5 +208,21 @@ export const loadExistingVectorStore = async () => {
     return retrievedMemVecs;
   } catch (error) {
     console.error("Error in loadExistingVectorStore: ", error)
+  };
+};
+
+export const checkUserHasKnowledgeBase = async () => {
+  console.log("Debug checkUserHasKnowledgeBase ");
+  try {
+    const checkResponse = await storeState.backendActor.check_caller_has_memory_vectors_entry();
+    console.log("Debug checkUserHasKnowledgeBase checkResponse ", checkResponse);
+    if (checkResponse.Ok) {
+      console.log("Debug checkUserHasKnowledgeBase checkResponse.Ok ", checkResponse.Ok);
+      return checkResponse.Ok;
+    } else {
+      return false;
+    };
+  } catch (error) {
+    console.error("Error in checkUserHasKnowledgeBase: ", error)
   };
 };

--- a/src/DeVinci_frontend/helpers/vector_database.ts
+++ b/src/DeVinci_frontend/helpers/vector_database.ts
@@ -152,10 +152,7 @@ export const storeEmbeddings = async () => {
   };
 };
 
-export const retrieveEmbeddings = async () => {
-  if (!vectorStoreState) {
-    return;
-  };
+const retrieveEmbeddings = async () => {
   try {
     let retrievedMemVecs = [];
     try {
@@ -170,5 +167,36 @@ export const retrieveEmbeddings = async () => {
     return retrievedMemVecs;
   } catch (error) {
     console.error("Error in retrieveEmbeddings: ", error)
+  };
+};
+
+export const loadExistingVectorStore = async () => {
+  try {
+    let retrievedMemVecs = await retrieveEmbeddings();
+    try {
+      const start = performance.now() / 1000;
+
+      const textsToEmbed = [];
+
+      const metadata = [];
+
+      const embeddings = new TensorFlowEmbeddings();
+
+      vectorStoreState = await MemoryVectorStore.fromTexts(
+        textsToEmbed,
+        metadata,
+        embeddings,
+      );
+      
+      vectorStore.set(vectorStoreState);
+
+      const end = performance.now() / 1000;
+      console.log(`Debug: loadExistingVectorStore took ${(end - start).toFixed(2)}s`);
+    } catch (error) {
+      console.error("Error loading retrieved vectors: ", error);        
+    };
+    return retrievedMemVecs;
+  } catch (error) {
+    console.error("Error in loadExistingVectorStore: ", error)
   };
 };

--- a/src/DeVinci_frontend/pages/UserSettings.svelte
+++ b/src/DeVinci_frontend/pages/UserSettings.svelte
@@ -62,7 +62,7 @@
         <div id="modelsetting">
             <h4 class="font-semibold">AI Model In Use</h4>
             <p>Please select the AI model you want to be used to power your DeVinci chat bot.</p>
-            <p>Note: AI models are pretty huge and require quite some computational resources. 
+            <p>Please note: AI models are pretty huge and require quite some computational resources. 
                 As DeVinci runs on your device (via the browser), whether and how fast it may run depend on the device's hardware. If a given model doesn't work, you can thus try a smaller one and see if the device can support it.</p>
             <p>For the best possible experience, we recommend running as few other programs and browser tabs as possible besides DeVinci as those can limit the computational resources available for DeVinci.</p>
             <div class="model-options">

--- a/src/DeVinci_frontend/service-worker.ts
+++ b/src/DeVinci_frontend/service-worker.ts
@@ -1,7 +1,7 @@
 import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
 import { clientsClaim, setCacheNameDetails } from 'workbox-core';
 import { registerRoute } from 'workbox-routing';
-import { StaleWhileRevalidate } from 'workbox-strategies';
+import { NetworkFirst } from 'workbox-strategies';
 
 declare let self: ServiceWorkerGlobalScope;
 
@@ -71,7 +71,7 @@ self.addEventListener('activate', (event) => {
 // Use a CacheFirst strategy for all requests (i.e. all requests are cached)
 registerRoute(
   ({ request }) => true,
-  new StaleWhileRevalidate({
+  new NetworkFirst({
     cacheName: CACHE_NAME,
     plugins: [
       // Optionally, configure plugins, e.g., to limit cache entries or expiration

--- a/src/DeVinci_frontend/service-worker.ts
+++ b/src/DeVinci_frontend/service-worker.ts
@@ -1,7 +1,7 @@
 import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
 import { clientsClaim, setCacheNameDetails } from 'workbox-core';
 import { registerRoute } from 'workbox-routing';
-import { CacheFirst } from 'workbox-strategies';
+import { StaleWhileRevalidate } from 'workbox-strategies';
 
 declare let self: ServiceWorkerGlobalScope;
 
@@ -71,7 +71,7 @@ self.addEventListener('activate', (event) => {
 // Use a CacheFirst strategy for all requests (i.e. all requests are cached)
 registerRoute(
   ({ request }) => true,
-  new CacheFirst({
+  new StaleWhileRevalidate({
     cacheName: CACHE_NAME,
     plugins: [
       // Optionally, configure plugins, e.g., to limit cache entries or expiration

--- a/src/declarations/DeVinci_backend/DeVinci_backend.did
+++ b/src/declarations/DeVinci_backend/DeVinci_backend.did
@@ -24,6 +24,23 @@ type Message =
    content: text;
    sender: text;
  };
+type MemoryVectorsStoredResult = 
+ variant {
+   Err: ApiError;
+   Ok: bool;
+ };
+type MemoryVectorsResult = 
+ variant {
+   Err: ApiError;
+   Ok: vec MemoryVector;
+ };
+type MemoryVectorMetadata = record {id: text;};
+type MemoryVector = 
+ record {
+   content: text;
+   embedding: vec float64;
+   metadata: MemoryVectorMetadata;
+ };
 type EmailSubscriber = 
  record {
    emailAddress: text;
@@ -37,6 +54,7 @@ type DeVinciBackend =
    delete_email_subscriber: (text) -> (bool);
    get_caller_chat_history: () -> (ChatsPreviewResult) query;
    get_caller_chats: () -> (ChatsResult) query;
+   get_caller_memory_vectors: () -> (MemoryVectorsResult) query;
    get_caller_settings: () -> (UserSettingsResult) query;
    get_chat: (text) -> (ChatResult) query;
    get_email_subscribers: () -> (vec record {
@@ -44,6 +62,8 @@ type DeVinciBackend =
                                        EmailSubscriber;
                                      }) query;
    greet: (text) -> (text);
+   store_user_chats_memory_vectors: (vec MemoryVector) ->
+    (MemoryVectorsStoredResult);
    submit_signup_form: (SignUpFormInput) -> (text);
    update_caller_settings: (UserSettings) -> (UpdateUserSettingsResult);
    update_chat_messages: (text, vec Message) -> (ChatIdResult);

--- a/src/declarations/DeVinci_backend/DeVinci_backend.did
+++ b/src/declarations/DeVinci_backend/DeVinci_backend.did
@@ -34,7 +34,12 @@ type MemoryVectorsResult =
    Err: ApiError;
    Ok: vec MemoryVector;
  };
-type MemoryVectorMetadata = record {id: text;};
+type MemoryVectorsCheckResult = 
+ variant {
+   Err: ApiError;
+   Ok: bool;
+ };
+type MemoryVectorMetadata = record {id: int;};
 type MemoryVector = 
  record {
    content: text;
@@ -49,6 +54,8 @@ type EmailSubscriber =
  };
 type DeVinciBackend = 
  service {
+   check_caller_has_memory_vectors_entry: () ->
+    (MemoryVectorsCheckResult) query;
    create_chat: (vec Message) -> (ChatCreationResult);
    delete_chat: (text) -> (ChatResult);
    delete_email_subscriber: (text) -> (bool);

--- a/src/declarations/DeVinci_backend/DeVinci_backend.did.d.ts
+++ b/src/declarations/DeVinci_backend/DeVinci_backend.did.d.ts
@@ -31,6 +31,10 @@ export type ChatsPreviewResult = { 'Ok' : Array<ChatPreview> } |
 export type ChatsResult = { 'Ok' : Array<Chat> } |
   { 'Err' : ApiError };
 export interface DeVinciBackend {
+  'check_caller_has_memory_vectors_entry' : ActorMethod<
+    [],
+    MemoryVectorsCheckResult
+  >,
   'create_chat' : ActorMethod<[Array<Message>], ChatCreationResult>,
   'delete_chat' : ActorMethod<[string], ChatResult>,
   'delete_email_subscriber' : ActorMethod<[string], boolean>,
@@ -63,7 +67,9 @@ export interface MemoryVector {
   'metadata' : MemoryVectorMetadata,
   'embedding' : Array<number>,
 }
-export interface MemoryVectorMetadata { 'id' : string }
+export interface MemoryVectorMetadata { 'id' : bigint }
+export type MemoryVectorsCheckResult = { 'Ok' : boolean } |
+  { 'Err' : ApiError };
 export type MemoryVectorsResult = { 'Ok' : Array<MemoryVector> } |
   { 'Err' : ApiError };
 export type MemoryVectorsStoredResult = { 'Ok' : boolean } |

--- a/src/declarations/DeVinci_backend/DeVinci_backend.did.d.ts
+++ b/src/declarations/DeVinci_backend/DeVinci_backend.did.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
 export type ApiError = { 'ZeroAddress' : null } |
   { 'InvalidTokenId' : null } |
@@ -35,10 +36,15 @@ export interface DeVinciBackend {
   'delete_email_subscriber' : ActorMethod<[string], boolean>,
   'get_caller_chat_history' : ActorMethod<[], ChatsPreviewResult>,
   'get_caller_chats' : ActorMethod<[], ChatsResult>,
+  'get_caller_memory_vectors' : ActorMethod<[], MemoryVectorsResult>,
   'get_caller_settings' : ActorMethod<[], UserSettingsResult>,
   'get_chat' : ActorMethod<[string], ChatResult>,
   'get_email_subscribers' : ActorMethod<[], Array<[string, EmailSubscriber]>>,
   'greet' : ActorMethod<[string], string>,
+  'store_user_chats_memory_vectors' : ActorMethod<
+    [Array<MemoryVector>],
+    MemoryVectorsStoredResult
+  >,
   'submit_signup_form' : ActorMethod<[SignUpFormInput], string>,
   'update_caller_settings' : ActorMethod<
     [UserSettings],
@@ -52,6 +58,16 @@ export interface EmailSubscriber {
   'emailAddress' : string,
   'pageSubmittedFrom' : string,
 }
+export interface MemoryVector {
+  'content' : string,
+  'metadata' : MemoryVectorMetadata,
+  'embedding' : Array<number>,
+}
+export interface MemoryVectorMetadata { 'id' : string }
+export type MemoryVectorsResult = { 'Ok' : Array<MemoryVector> } |
+  { 'Err' : ApiError };
+export type MemoryVectorsStoredResult = { 'Ok' : boolean } |
+  { 'Err' : ApiError };
 export interface Message { 'content' : string, 'sender' : string }
 export interface SignUpFormInput {
   'emailAddress' : string,
@@ -64,3 +80,5 @@ export interface UserSettings { 'selectedAiModelId' : string }
 export type UserSettingsResult = { 'Ok' : UserSettings } |
   { 'Err' : ApiError };
 export interface _SERVICE extends DeVinciBackend {}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/DeVinci_backend/DeVinci_backend.did.js
+++ b/src/declarations/DeVinci_backend/DeVinci_backend.did.js
@@ -1,11 +1,15 @@
 export const idlFactory = ({ IDL }) => {
-  const Message = IDL.Record({ 'content' : IDL.Text, 'sender' : IDL.Text });
   const ApiError = IDL.Variant({
     'ZeroAddress' : IDL.Null,
     'InvalidTokenId' : IDL.Null,
     'Unauthorized' : IDL.Null,
     'Other' : IDL.Text,
   });
+  const MemoryVectorsCheckResult = IDL.Variant({
+    'Ok' : IDL.Bool,
+    'Err' : ApiError,
+  });
+  const Message = IDL.Record({ 'content' : IDL.Text, 'sender' : IDL.Text });
   const ChatCreationResult = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : ApiError });
   const Chat = IDL.Record({
     'id' : IDL.Text,
@@ -27,7 +31,7 @@ export const idlFactory = ({ IDL }) => {
     'Err' : ApiError,
   });
   const ChatsResult = IDL.Variant({ 'Ok' : IDL.Vec(Chat), 'Err' : ApiError });
-  const MemoryVectorMetadata = IDL.Record({ 'id' : IDL.Text });
+  const MemoryVectorMetadata = IDL.Record({ 'id' : IDL.Int });
   const MemoryVector = IDL.Record({
     'content' : IDL.Text,
     'metadata' : MemoryVectorMetadata,
@@ -65,6 +69,11 @@ export const idlFactory = ({ IDL }) => {
     'chatTitle' : IDL.Text,
   });
   const DeVinciBackend = IDL.Service({
+    'check_caller_has_memory_vectors_entry' : IDL.Func(
+        [],
+        [MemoryVectorsCheckResult],
+        ['query'],
+      ),
     'create_chat' : IDL.Func([IDL.Vec(Message)], [ChatCreationResult], []),
     'delete_chat' : IDL.Func([IDL.Text], [ChatResult], []),
     'delete_email_subscriber' : IDL.Func([IDL.Text], [IDL.Bool], []),

--- a/src/declarations/DeVinci_backend/DeVinci_backend.did.js
+++ b/src/declarations/DeVinci_backend/DeVinci_backend.did.js
@@ -27,6 +27,16 @@ export const idlFactory = ({ IDL }) => {
     'Err' : ApiError,
   });
   const ChatsResult = IDL.Variant({ 'Ok' : IDL.Vec(Chat), 'Err' : ApiError });
+  const MemoryVectorMetadata = IDL.Record({ 'id' : IDL.Text });
+  const MemoryVector = IDL.Record({
+    'content' : IDL.Text,
+    'metadata' : MemoryVectorMetadata,
+    'embedding' : IDL.Vec(IDL.Float64),
+  });
+  const MemoryVectorsResult = IDL.Variant({
+    'Ok' : IDL.Vec(MemoryVector),
+    'Err' : ApiError,
+  });
   const UserSettings = IDL.Record({ 'selectedAiModelId' : IDL.Text });
   const UserSettingsResult = IDL.Variant({
     'Ok' : UserSettings,
@@ -36,6 +46,10 @@ export const idlFactory = ({ IDL }) => {
     'subscribedAt' : IDL.Nat64,
     'emailAddress' : IDL.Text,
     'pageSubmittedFrom' : IDL.Text,
+  });
+  const MemoryVectorsStoredResult = IDL.Variant({
+    'Ok' : IDL.Bool,
+    'Err' : ApiError,
   });
   const SignUpFormInput = IDL.Record({
     'emailAddress' : IDL.Text,
@@ -56,6 +70,11 @@ export const idlFactory = ({ IDL }) => {
     'delete_email_subscriber' : IDL.Func([IDL.Text], [IDL.Bool], []),
     'get_caller_chat_history' : IDL.Func([], [ChatsPreviewResult], ['query']),
     'get_caller_chats' : IDL.Func([], [ChatsResult], ['query']),
+    'get_caller_memory_vectors' : IDL.Func(
+        [],
+        [MemoryVectorsResult],
+        ['query'],
+      ),
     'get_caller_settings' : IDL.Func([], [UserSettingsResult], ['query']),
     'get_chat' : IDL.Func([IDL.Text], [ChatResult], ['query']),
     'get_email_subscribers' : IDL.Func(
@@ -64,6 +83,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'greet' : IDL.Func([IDL.Text], [IDL.Text], []),
+    'store_user_chats_memory_vectors' : IDL.Func(
+        [IDL.Vec(MemoryVector)],
+        [MemoryVectorsStoredResult],
+        [],
+      ),
     'submit_signup_form' : IDL.Func([SignUpFormInput], [IDL.Text], []),
     'update_caller_settings' : IDL.Func(
         [UserSettings],

--- a/src/declarations/DeVinci_backend/index.js
+++ b/src/declarations/DeVinci_backend/index.js
@@ -10,8 +10,7 @@ export { idlFactory } from "./DeVinci_backend.did.js";
  * beginning in dfx 0.15.0
  */
 export const canisterId =
-  process.env.CANISTER_ID_DEVINCI_BACKEND ||
-  process.env.DEVINCI_BACKEND_CANISTER_ID;
+  process.env.CANISTER_ID_DEVINCI_BACKEND;
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });
@@ -40,4 +39,4 @@ export const createActor = (canisterId, options = {}) => {
   });
 };
 
-export const DeVinci_backend = createActor(canisterId);
+export const DeVinci_backend = canisterId ? createActor(canisterId) : undefined;

--- a/src/declarations/DeVinci_frontend/DeVinci_frontend.did
+++ b/src/declarations/DeVinci_frontend/DeVinci_frontend.did
@@ -139,7 +139,25 @@ type ListPermitted = record { permission: Permission };
 
 type ValidationResult = variant { Ok : text; Err : text };
 
-service: {
+type AssetCanisterArgs = variant {
+  Init: InitArgs;
+  Upgrade: UpgradeArgs;
+};
+
+type InitArgs = record {};
+
+type UpgradeArgs = record {
+  set_permissions: opt SetPermissions;
+};
+
+/// Sets the list of principals granted each permission.
+type SetPermissions = record {
+  prepare: vec principal;
+  commit: vec principal;
+  manage_permissions: vec principal;
+};
+
+service: (asset_canister_args: opt AssetCanisterArgs) -> {
   api_version: () -> (nat16) query;
 
   get: (record {
@@ -220,10 +238,10 @@ service: {
 
   authorize: (principal) -> ();
   deauthorize: (principal) -> ();
-  list_authorized: () -> (vec principal) query;
+  list_authorized: () -> (vec principal);
   grant_permission: (GrantPermission) -> ();
   revoke_permission: (RevokePermission) -> ();
-  list_permitted: (ListPermitted) -> (vec principal) query;
+  list_permitted: (ListPermitted) -> (vec principal);
   take_ownership: () -> ();
 
   get_asset_properties : (key: Key) -> (record {

--- a/src/declarations/DeVinci_frontend/DeVinci_frontend.did.d.ts
+++ b/src/declarations/DeVinci_frontend/DeVinci_frontend.did.d.ts
@@ -1,6 +1,9 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
 
+export type AssetCanisterArgs = { 'Upgrade' : UpgradeArgs } |
+  { 'Init' : InitArgs };
 export type BatchId = bigint;
 export type BatchOperationKind = {
     'SetAssetProperties' : SetAssetPropertiesArguments
@@ -62,6 +65,7 @@ export interface HttpResponse {
   'streaming_strategy' : [] | [StreamingStrategy],
   'status_code' : number,
 }
+export type InitArgs = {};
 export type Key = string;
 export interface ListPermitted { 'permission' : Permission }
 export type Permission = { 'Prepare' : null } |
@@ -84,6 +88,11 @@ export interface SetAssetPropertiesArguments {
   'allow_raw_access' : [] | [[] | [boolean]],
   'max_age' : [] | [[] | [bigint]],
 }
+export interface SetPermissions {
+  'prepare' : Array<Principal>,
+  'commit' : Array<Principal>,
+  'manage_permissions' : Array<Principal>,
+}
 export interface StreamingCallbackHttpResponse {
   'token' : [] | [StreamingCallbackToken],
   'body' : Uint8Array | number[],
@@ -105,6 +114,7 @@ export interface UnsetAssetContentArguments {
   'key' : Key,
   'content_encoding' : string,
 }
+export interface UpgradeArgs { 'set_permissions' : [] | [SetPermissions] }
 export type ValidationResult = { 'Ok' : string } |
   { 'Err' : string };
 export interface _SERVICE {
@@ -226,3 +236,5 @@ export interface _SERVICE {
   >,
   'validate_take_ownership' : ActorMethod<[], ValidationResult>,
 }
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/DeVinci_frontend/DeVinci_frontend.did.js
+++ b/src/declarations/DeVinci_frontend/DeVinci_frontend.did.js
@@ -1,4 +1,17 @@
 export const idlFactory = ({ IDL }) => {
+  const SetPermissions = IDL.Record({
+    'prepare' : IDL.Vec(IDL.Principal),
+    'commit' : IDL.Vec(IDL.Principal),
+    'manage_permissions' : IDL.Vec(IDL.Principal),
+  });
+  const UpgradeArgs = IDL.Record({
+    'set_permissions' : IDL.Opt(SetPermissions),
+  });
+  const InitArgs = IDL.Record({});
+  const AssetCanisterArgs = IDL.Variant({
+    'Upgrade' : UpgradeArgs,
+    'Init' : InitArgs,
+  });
   const ClearArguments = IDL.Record({});
   const BatchId = IDL.Nat;
   const Key = IDL.Text;
@@ -211,12 +224,8 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'list_authorized' : IDL.Func([], [IDL.Vec(IDL.Principal)], ['query']),
-    'list_permitted' : IDL.Func(
-        [ListPermitted],
-        [IDL.Vec(IDL.Principal)],
-        ['query'],
-      ),
+    'list_authorized' : IDL.Func([], [IDL.Vec(IDL.Principal)], []),
+    'list_permitted' : IDL.Func([ListPermitted], [IDL.Vec(IDL.Principal)], []),
     'propose_commit_batch' : IDL.Func([CommitBatchArguments], [], []),
     'revoke_permission' : IDL.Func([RevokePermission], [], []),
     'set_asset_content' : IDL.Func([SetAssetContentArguments], [], []),
@@ -259,4 +268,19 @@ export const idlFactory = ({ IDL }) => {
     'validate_take_ownership' : IDL.Func([], [ValidationResult], []),
   });
 };
-export const init = ({ IDL }) => { return []; };
+export const init = ({ IDL }) => {
+  const SetPermissions = IDL.Record({
+    'prepare' : IDL.Vec(IDL.Principal),
+    'commit' : IDL.Vec(IDL.Principal),
+    'manage_permissions' : IDL.Vec(IDL.Principal),
+  });
+  const UpgradeArgs = IDL.Record({
+    'set_permissions' : IDL.Opt(SetPermissions),
+  });
+  const InitArgs = IDL.Record({});
+  const AssetCanisterArgs = IDL.Variant({
+    'Upgrade' : UpgradeArgs,
+    'Init' : InitArgs,
+  });
+  return [IDL.Opt(AssetCanisterArgs)];
+};

--- a/src/declarations/internet_identity/index.d.ts
+++ b/src/declarations/internet_identity/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './internet_identity.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const internet_identity: ActorSubclass<_SERVICE>;

--- a/src/declarations/internet_identity/index.js
+++ b/src/declarations/internet_identity/index.js
@@ -1,8 +1,8 @@
 import { Actor, HttpAgent } from "@dfinity/agent";
 
 // Imports and re-exports candid interface
-import { idlFactory } from "./DeVinci_frontend.did.js";
-export { idlFactory } from "./DeVinci_frontend.did.js";
+import { idlFactory } from "./internet_identity.did.js";
+export { idlFactory } from "./internet_identity.did.js";
 
 /* CANISTER_ID is replaced by webpack based on node environment
  * Note: canister environment variable will be standardized as
@@ -10,7 +10,7 @@ export { idlFactory } from "./DeVinci_frontend.did.js";
  * beginning in dfx 0.15.0
  */
 export const canisterId =
-  process.env.CANISTER_ID_DEVINCI_FRONTEND;
+  process.env.CANISTER_ID_INTERNET_IDENTITY;
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });
@@ -39,4 +39,4 @@ export const createActor = (canisterId, options = {}) => {
   });
 };
 
-export const DeVinci_frontend = canisterId ? createActor(canisterId) : undefined;
+export const internet_identity = canisterId ? createActor(canisterId) : undefined;

--- a/src/declarations/internet_identity/internet_identity.did
+++ b/src/declarations/internet_identity/internet_identity.did
@@ -1,0 +1,620 @@
+type UserNumber = nat64;
+type PublicKey = blob;
+type CredentialId = blob;
+type DeviceKey = PublicKey;
+type UserKey = PublicKey;
+type SessionKey = PublicKey;
+type FrontendHostname = text;
+type Timestamp = nat64;
+
+type HeaderField = record {
+    text;
+    text;
+};
+
+type HttpRequest = record {
+    method: text;
+    url: text;
+    headers: vec HeaderField;
+    body: blob;
+    certificate_version: opt nat16;
+};
+
+type HttpResponse = record {
+    status_code: nat16;
+    headers: vec HeaderField;
+    body: blob;
+    upgrade : opt bool;
+    streaming_strategy: opt StreamingStrategy;
+};
+
+type StreamingCallbackHttpResponse = record {
+    body: blob;
+    token: opt Token;
+};
+
+type Token = record {};
+
+type StreamingStrategy = variant {
+    Callback: record {
+        callback: func (Token) -> (StreamingCallbackHttpResponse) query;
+        token: Token;
+    };
+};
+
+type Purpose = variant {
+    recovery;
+    authentication;
+};
+
+type KeyType = variant {
+    unknown;
+    platform;
+    cross_platform;
+    seed_phrase;
+    browser_storage_key;
+};
+
+// This describes whether a device is "protected" or not.
+// When protected, a device can only be updated or removed if the
+// user is authenticated with that very device.
+type DeviceProtection = variant {
+    protected;
+    unprotected;
+};
+
+type Challenge = record {
+    png_base64: text;
+    challenge_key: ChallengeKey;
+};
+
+type DeviceData = record {
+    pubkey : DeviceKey;
+    alias : text;
+    credential_id : opt CredentialId;
+    purpose: Purpose;
+    key_type: KeyType;
+    protection: DeviceProtection;
+    origin: opt text;
+    // Metadata map for additional device information.
+    //
+    // Note: some fields above will be moved to the metadata map in the future.
+    // All field names of `DeviceData` (such as 'alias', 'origin, etc.) are
+    // reserved and cannot be written.
+    // In addition, the keys "usage" and "authenticator_attachment" are reserved as well.
+    metadata: opt MetadataMap;
+};
+
+// The same as `DeviceData` but with the `last_usage` field.
+// This field cannot be written, hence the separate type.
+type DeviceWithUsage = record {
+    pubkey : DeviceKey;
+    alias : text;
+    credential_id : opt CredentialId;
+    purpose: Purpose;
+    key_type: KeyType;
+    protection: DeviceProtection;
+    origin: opt text;
+    last_usage: opt Timestamp;
+    metadata: opt MetadataMap;
+};
+
+// Map with some variants for the value type.
+// Note, due to the Candid mapping this must be a tuple type thus we cannot name the fields `key` and `value`.
+type MetadataMap = vec record {
+    text;
+    variant { map : MetadataMap; string : text; bytes : vec nat8 };
+};
+
+type RegisterResponse = variant {
+    // A new user was successfully registered.
+    registered: record {
+        user_number: UserNumber;
+    };
+    // No more registrations are possible in this instance of the II service canister.
+    canister_full;
+    // The challenge was not successful.
+    bad_challenge;
+};
+
+type AddTentativeDeviceResponse = variant {
+    // The device was tentatively added.
+    added_tentatively: record {
+        verification_code: text;
+        // Expiration date, in nanos since the epoch
+        device_registration_timeout: Timestamp;
+    };
+    // Device registration mode is off, either due to timeout or because it was never enabled.
+    device_registration_mode_off;
+    // There is another device already added tentatively
+    another_device_tentatively_added;
+};
+
+type VerifyTentativeDeviceResponse = variant {
+    // The device was successfully verified.
+    verified;
+    // Wrong verification code entered. Retry with correct code.
+    wrong_code: record {
+        retries_left: nat8
+    };
+    // Device registration mode is off, either due to timeout or because it was never enabled.
+    device_registration_mode_off;
+    // There is no tentative device to be verified.
+    no_device_to_verify;
+};
+
+type Delegation = record {
+    pubkey: PublicKey;
+    expiration: Timestamp;
+    targets: opt vec principal;
+};
+
+type SignedDelegation = record {
+    delegation: Delegation;
+    signature: blob;
+};
+
+type GetDelegationResponse = variant {
+    // The signed delegation was successfully retrieved.
+    signed_delegation: SignedDelegation;
+
+    // The signature is not ready. Maybe retry by calling `prepare_delegation`
+    no_such_delegation
+};
+
+type InternetIdentityStats = record {
+    users_registered: nat64;
+    storage_layout_version: nat8;
+    assigned_user_number_range: record {
+        nat64;
+        nat64;
+    };
+    archive_info: ArchiveInfo;
+    canister_creation_cycles_cost: nat64;
+    max_num_latest_delegation_origins: nat64;
+    latest_delegation_origins: vec FrontendHostname
+};
+
+// Configuration parameters related to the archive.
+type ArchiveConfig = record {
+    // The allowed module hash of the archive canister.
+    // Changing this parameter does _not_ deploy the archive, but enable archive deployments with the
+    // corresponding wasm module.
+    module_hash : blob;
+    // Buffered archive entries limit. If reached, II will stop accepting new anchor operations
+    // until the buffered operations are acknowledged by the archive.
+    entries_buffer_limit: nat64;
+    // The maximum number of entries to be transferred to the archive per call.
+    entries_fetch_limit: nat16;
+    // Polling interval to fetch new entries from II (in nanoseconds).
+    // Changes to this parameter will only take effect after an archive deployment.
+    polling_interval_ns: nat64;
+};
+
+// Information about the archive.
+type ArchiveInfo = record {
+    // Canister id of the archive or empty if no archive has been deployed yet.
+    archive_canister : opt principal;
+    // Configuration parameters related to the II archive.
+    archive_config: opt ArchiveConfig;
+};
+
+// Rate limit configuration.
+// Currently only used for `register`.
+type RateLimitConfig = record {
+    // Time it takes (in ns) for a rate limiting token to be replenished.
+    time_per_token_ns : nat64;
+    // How many tokens are at most generated (to accommodate peaks).
+    max_tokens: nat64;
+};
+
+// Init arguments of II which can be supplied on install and upgrade.
+// Setting a value to null keeps the previous value.
+type InternetIdentityInit = record {
+    // Set lowest and highest anchor
+    assigned_user_number_range : opt record {
+        nat64;
+        nat64;
+    };
+    // Configuration parameters related to the II archive.
+    // Note: some parameters changes (like the polling interval) will only take effect after an archive deployment.
+    // See ArchiveConfig for details.
+    archive_config: opt ArchiveConfig;
+    // Set the amounts of cycles sent with the create canister message.
+    // This is configurable because in the staging environment cycles are required.
+    // The canister creation cost on mainnet is currently 100'000'000'000 cycles. If this value is higher thant the
+    // canister creation cost, the newly created canister will keep extra cycles.
+    canister_creation_cycles_cost : opt nat64;
+    // Rate limit for the `register` call.
+    register_rate_limit : opt RateLimitConfig;
+    // Maximum number of latest delegation origins to track.
+    // Default: 1000
+    max_num_latest_delegation_origins : opt nat64;
+    // Maximum number of inflight captchas.
+    // Default: 500
+    max_inflight_captchas: opt nat64;
+};
+
+type ChallengeKey = text;
+
+type ChallengeResult = record {
+    key : ChallengeKey;
+    chars : text;
+};
+type CaptchaResult = ChallengeResult;
+
+// Extra information about registration status for new devices
+type DeviceRegistrationInfo = record {
+    // If present, the user has tentatively added a new device. This
+    // new device needs to be verified (see relevant endpoint) before
+    // 'expiration'.
+    tentative_device : opt DeviceData;
+    // The timestamp at which the anchor will turn off registration mode
+    // (and the tentative device will be forgotten, if any, and if not verified)
+    expiration: Timestamp;
+};
+
+// Information about the anchor
+type IdentityAnchorInfo = record {
+    // All devices that can authenticate to this anchor
+    devices : vec DeviceWithUsage;
+    // Device registration status used when adding devices, see DeviceRegistrationInfo
+    device_registration: opt DeviceRegistrationInfo;
+};
+
+type AnchorCredentials = record {
+    credentials : vec WebAuthnCredential;
+    recovery_credentials : vec WebAuthnCredential;
+    recovery_phrases: vec PublicKey;
+};
+
+type WebAuthnCredential = record {
+    credential_id : CredentialId;
+    pubkey: PublicKey;
+};
+
+type DeployArchiveResult = variant {
+    // The archive was deployed successfully and the supplied wasm module has been installed. The principal of the archive
+    // canister is returned.
+    success: principal;
+    // Initial archive creation is already in progress.
+    creation_in_progress;
+    // Archive deployment failed. An error description is returned.
+    failed: text;
+};
+
+type BufferedArchiveEntry = record {
+    anchor_number: UserNumber;
+    timestamp: Timestamp;
+    sequence_number: nat64;
+    entry: blob;
+};
+
+// API V2 specific types
+// WARNING: These type are experimental and may change in the future.
+
+type IdentityNumber = nat64;
+
+// Map with some variants for the value type.
+// Note, due to the Candid mapping this must be a tuple type thus we cannot name the fields `key` and `value`.
+type MetadataMapV2 = vec record {
+    text;
+    variant { Map : MetadataMapV2; String : text; Bytes : vec nat8 };
+};
+
+// Authentication method using WebAuthn signatures
+// See https://www.w3.org/TR/webauthn-2/
+// This is a separate type because WebAuthn requires to also store
+// the credential id (in addition to the public key).
+type WebAuthn = record {
+    credential_id: CredentialId;
+    pubkey: PublicKey;
+};
+
+// Authentication method using generic signatures
+// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#signatures for
+// supported signature schemes.
+type PublicKeyAuthn = record {
+    pubkey: PublicKey;
+};
+
+// The authentication methods currently supported by II.
+type AuthnMethod = variant {
+    WebAuthn: WebAuthn;
+    PubKey: PublicKeyAuthn;
+};
+
+// This describes whether an authentication method is "protected" or not.
+// When protected, a authentication method can only be updated or removed if the
+// user is authenticated with that very authentication method.
+type AuthnMethodProtection = variant {
+    Protected;
+    Unprotected;
+};
+
+type AuthnMethodPurpose = variant {
+    Recovery;
+    Authentication;
+};
+
+type AuthnMethodSecuritySettings = record {
+    protection: AuthnMethodProtection;
+    purpose: AuthnMethodPurpose;
+};
+
+type AuthnMethodData = record {
+    authn_method: AuthnMethod;
+    security_settings: AuthnMethodSecuritySettings;
+    // contains the following fields of the DeviceWithUsage type:
+    // - alias
+    // - origin
+    // - authenticator_attachment: data taken from key_type and reduced to "platform", "cross_platform" or absent on migration
+    // - usage: data taken from key_type and reduced to "recovery_phrase", "browser_storage_key" or absent on migration
+    // Note: for compatibility reasons with the v1 API, the entries above (if present)
+    // must be of the `String` variant. This restriction may be lifted in the future.
+    metadata: MetadataMapV2;
+    last_authentication: opt Timestamp;
+};
+
+// Extra information about registration status for new authentication methods
+type AuthnMethodRegistrationInfo = record {
+    // If present, the user has registered a new authentication method. This
+    // new authentication needs to be verified before 'expiration' in order to
+    // be added to the identity.
+    authn_method : opt AuthnMethodData;
+    // The timestamp at which the identity will turn off registration mode
+    // (and the authentication method will be forgotten, if any, and if not verified)
+    expiration: Timestamp;
+};
+
+type AuthnMethodConfirmationCode = record {
+    confirmation_code: text;
+    expiration: Timestamp;
+};
+
+type AuthnMethodRegisterError = variant {
+    // Authentication method registration mode is off, either due to timeout or because it was never enabled.
+    RegistrationModeOff;
+    // There is another authentication method already registered that needs to be confirmed first.
+    RegistrationAlreadyInProgress;
+    // The metadata of the provided authentication method contains invalid entries.
+    InvalidMetadata: text;
+};
+
+type AuthnMethodConfirmationError = variant {
+    // Wrong confirmation code entered. Retry with correct code.
+    WrongCode: record {
+        retries_left: nat8
+    };
+    // Authentication method registration mode is off, either due to timeout or because it was never enabled.
+    RegistrationModeOff;
+    // There is no registered authentication method to be confirmed.
+    NoAuthnMethodToConfirm;
+};
+
+type IdentityAuthnInfo = record {
+    authn_methods: vec AuthnMethod;
+    recovery_authn_methods: vec AuthnMethod;
+};
+
+type IdentityInfo = record {
+    authn_methods: vec AuthnMethodData;
+    authn_method_registration: opt AuthnMethodRegistrationInfo;
+    // Authentication method independent metadata
+    metadata: MetadataMapV2;
+};
+
+type IdentityInfoError = variant {
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
+};
+
+
+
+type IdentityRegisterError = variant {
+    // No more registrations are possible in this instance of the II service canister.
+    CanisterFull;
+    // The captcha check was not successful.
+    BadCaptcha;
+    // The metadata of the provided authentication method contains invalid entries.
+    InvalidMetadata: text;
+};
+
+type AuthnMethodAddError = variant {
+    InvalidMetadata: text;
+};
+
+type AuthnMethodReplaceError = variant {
+    InvalidMetadata: text;
+    // No authentication method found with the given public key.
+    AuthnMethodNotFound;
+};
+
+type AuthnMethodMetadataReplaceError = variant {
+    InvalidMetadata: text;
+    /// No authentication method found with the given public key.
+    AuthnMethodNotFound;
+};
+
+type AuthnMethodSecuritySettingsReplaceError = variant {
+    /// No authentication method found with the given public key.
+    AuthnMethodNotFound;
+};
+
+type IdentityMetadataReplaceError = variant {
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// The identity including the new metadata exceeds the maximum allowed size.
+    StorageSpaceExceeded: record {space_available: nat64; space_required: nat64};
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
+};
+
+type PrepareIdAliasRequest = record {
+    /// Origin of the issuer in the attribute sharing flow.
+    issuer : FrontendHostname;
+    /// Origin of the relying party in the attribute sharing flow.
+    relying_party : FrontendHostname;
+    /// Identity for which the IdAlias should be generated.
+    identity_number : IdentityNumber;
+};
+
+type PrepareIdAliasError = variant {
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
+};
+
+/// The prepared id alias contains two (still unsigned) credentials in JWT format,
+/// certifying the id alias for the issuer resp. the relying party.
+type PreparedIdAlias = record {
+    rp_id_alias_jwt : text;
+    issuer_id_alias_jwt : text;
+    canister_sig_pk_der : PublicKey;
+};
+
+/// The request to retrieve the actual signed id alias credentials.
+/// The field values should be equal to the values of corresponding
+/// fields from the preceding `PrepareIdAliasRequest` and `PrepareIdAliasResponse`.
+type GetIdAliasRequest = record {
+    rp_id_alias_jwt : text;
+    issuer : FrontendHostname;
+    issuer_id_alias_jwt : text;
+    relying_party : FrontendHostname;
+    identity_number : IdentityNumber;
+};
+
+type GetIdAliasError = variant {
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
+    NoSuchCredentials : text;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
+};
+
+/// The signed id alias credentials for each involved party.
+type IdAliasCredentials = record {
+    rp_id_alias_credential : SignedIdAlias;
+    issuer_id_alias_credential : SignedIdAlias;
+};
+
+type SignedIdAlias = record {
+    credential_jws : text;
+    id_alias : principal;
+    id_dapp : principal;
+};
+
+service : (opt InternetIdentityInit) -> {
+    init_salt: () -> ();
+    create_challenge : () -> (Challenge);
+    register : (DeviceData, ChallengeResult, opt principal) -> (RegisterResponse);
+    add : (UserNumber, DeviceData) -> ();
+    update : (UserNumber, DeviceKey, DeviceData) -> ();
+    // Atomically replace device matching the device key with the new device data
+    replace : (UserNumber, DeviceKey, DeviceData) -> ();
+    remove : (UserNumber, DeviceKey) -> ();
+    // Returns all devices of the user (authentication and recovery) but no information about device registrations.
+    // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
+    // Deprecated: Use 'get_anchor_credentials' instead.
+    lookup : (UserNumber) -> (vec DeviceData) query;
+    get_anchor_credentials : (UserNumber) -> (AnchorCredentials) query;
+    get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
+    get_principal : (UserNumber, FrontendHostname) -> (principal) query;
+    stats : () -> (InternetIdentityStats) query;
+
+    enter_device_registration_mode : (UserNumber) -> (Timestamp);
+    exit_device_registration_mode : (UserNumber) -> ();
+    add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse);
+    verify_tentative_device : (UserNumber, verification_code: text) -> (VerifyTentativeDeviceResponse);
+
+    prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
+    get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;
+
+    http_request: (request: HttpRequest) -> (HttpResponse) query;
+    http_request_update: (request: HttpRequest) -> (HttpResponse);
+
+    deploy_archive: (wasm: blob) -> (DeployArchiveResult);
+    /// Returns a batch of entries _sorted by sequence number_ to be archived.
+    /// This is an update call because the archive information _must_ be certified.
+    /// Only callable by this IIs archive canister.
+    fetch_entries: () -> (vec BufferedArchiveEntry);
+    acknowledge_entries: (sequence_number: nat64) -> ();
+
+    // V2 API
+    // WARNING: The following methods are experimental and may change in the future.
+
+    // Creates a new captcha. The solution needs to be submitted using the
+    // `identity_register` call.
+    captcha_create: () -> (variant {Ok: Challenge; Err;});
+
+    // Registers a new identity with the given authn_method.
+    // A valid captcha solution to a previously generated captcha (using create_captcha) must be provided.
+    // The sender needs to match the supplied authn_method.
+    identity_register: (AuthnMethodData, CaptchaResult, opt principal) -> (variant {Ok: IdentityNumber; Err: IdentityRegisterError;});
+
+    // Returns information about the authentication methods of the identity with the given number.
+    // Only returns the minimal information required for authentication without exposing any metadata such as aliases.
+    identity_authn_info: (IdentityNumber) -> (variant {Ok: IdentityAuthnInfo; Err;}) query;
+
+    // Returns information about the identity with the given number.
+    // Requires authentication.
+    identity_info: (IdentityNumber) -> (variant {Ok: IdentityInfo; Err: IdentityInfoError;});
+
+    // Replaces the authentication method independent metadata map.
+    // The existing metadata map will be overwritten.
+    // Requires authentication.
+    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err: IdentityMetadataReplaceError;});
+
+    // Adds a new authentication method to the identity.
+    // Requires authentication.
+    authn_method_add: (IdentityNumber, AuthnMethodData) -> (variant {Ok; Err: AuthnMethodAddError;});
+
+    // Atomically replaces the authentication method matching the supplied public key with the new authentication method
+    // provided.
+    // Requires authentication.
+    authn_method_replace: (IdentityNumber, PublicKey, AuthnMethodData) -> (variant {Ok; Err: AuthnMethodReplaceError;});
+
+    // Replaces the authentication method metadata map.
+    // The existing metadata map will be overwritten.
+    // Requires authentication.
+    authn_method_metadata_replace: (IdentityNumber, PublicKey, MetadataMapV2) -> (variant {Ok; Err: AuthnMethodMetadataReplaceError;});
+
+    // Replaces the authentication method security settings.
+    // The existing security settings will be overwritten.
+    // Requires authentication.
+    authn_method_security_settings_replace: (IdentityNumber, PublicKey, AuthnMethodSecuritySettings) -> (variant {Ok; Err: AuthnMethodSecuritySettingsReplaceError;});
+
+    // Removes the authentication method associated with the public key from the identity.
+    // Requires authentication.
+    authn_method_remove: (IdentityNumber, PublicKey) -> (variant {Ok; Err;});
+
+    // Enters the authentication method registration mode for the identity.
+    // In this mode, a new authentication method can be registered, which then needs to be
+    // confirmed before it can be used for authentication on this identity.
+    // The registration mode is automatically exited after the returned expiration timestamp.
+    // Requires authentication.
+    authn_method_registration_mode_enter : (IdentityNumber) -> (variant {Ok: record { expiration: Timestamp; }; Err;});
+
+    // Exits the authentication method registration mode for the identity.
+    // Requires authentication.
+    authn_method_registration_mode_exit : (IdentityNumber) -> (variant {Ok; Err;});
+
+    // Registers a new authentication method to the identity.
+    // This authentication method needs to be confirmed before it can be used for authentication on this identity.
+    authn_method_register: (IdentityNumber, AuthnMethodData) -> (variant {Ok: AuthnMethodConfirmationCode; Err: AuthnMethodRegisterError;});
+
+    // Confirms a previously registered authentication method.
+    // On successful confirmation, the authentication method is permanently added to the identity and can
+    // subsequently be used for authentication for that identity.
+    // Requires authentication.
+    authn_method_confirm: (IdentityNumber, confirmation_code: text) -> (variant {Ok; Err: AuthnMethodConfirmationError;});
+
+    // Attribute Sharing MVP API
+    // The methods below are used to generate ID-alias credentials during attribute sharing flow.
+    prepare_id_alias : (PrepareIdAliasRequest) -> (variant {Ok: PreparedIdAlias; Err: PrepareIdAliasError;});
+    get_id_alias : (GetIdAliasRequest) -> (variant {Ok: IdAliasCredentials; Err: GetIdAliasError;}) query;
+}

--- a/src/declarations/internet_identity/internet_identity.did.d.ts
+++ b/src/declarations/internet_identity/internet_identity.did.d.ts
@@ -1,0 +1,392 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+
+export type AddTentativeDeviceResponse = {
+    'device_registration_mode_off' : null
+  } |
+  { 'another_device_tentatively_added' : null } |
+  {
+    'added_tentatively' : {
+      'verification_code' : string,
+      'device_registration_timeout' : Timestamp,
+    }
+  };
+export interface AnchorCredentials {
+  'recovery_phrases' : Array<PublicKey>,
+  'credentials' : Array<WebAuthnCredential>,
+  'recovery_credentials' : Array<WebAuthnCredential>,
+}
+export interface ArchiveConfig {
+  'polling_interval_ns' : bigint,
+  'entries_buffer_limit' : bigint,
+  'module_hash' : Uint8Array | number[],
+  'entries_fetch_limit' : number,
+}
+export interface ArchiveInfo {
+  'archive_config' : [] | [ArchiveConfig],
+  'archive_canister' : [] | [Principal],
+}
+export type AuthnMethod = { 'PubKey' : PublicKeyAuthn } |
+  { 'WebAuthn' : WebAuthn };
+export type AuthnMethodAddError = { 'InvalidMetadata' : string };
+export interface AuthnMethodConfirmationCode {
+  'confirmation_code' : string,
+  'expiration' : Timestamp,
+}
+export type AuthnMethodConfirmationError = { 'RegistrationModeOff' : null } |
+  { 'NoAuthnMethodToConfirm' : null } |
+  { 'WrongCode' : { 'retries_left' : number } };
+export interface AuthnMethodData {
+  'security_settings' : AuthnMethodSecuritySettings,
+  'metadata' : MetadataMapV2,
+  'last_authentication' : [] | [Timestamp],
+  'authn_method' : AuthnMethod,
+}
+export type AuthnMethodMetadataReplaceError = { 'AuthnMethodNotFound' : null } |
+  { 'InvalidMetadata' : string };
+export type AuthnMethodProtection = { 'Protected' : null } |
+  { 'Unprotected' : null };
+export type AuthnMethodPurpose = { 'Recovery' : null } |
+  { 'Authentication' : null };
+export type AuthnMethodRegisterError = { 'RegistrationModeOff' : null } |
+  { 'RegistrationAlreadyInProgress' : null } |
+  { 'InvalidMetadata' : string };
+export interface AuthnMethodRegistrationInfo {
+  'expiration' : Timestamp,
+  'authn_method' : [] | [AuthnMethodData],
+}
+export type AuthnMethodReplaceError = { 'AuthnMethodNotFound' : null } |
+  { 'InvalidMetadata' : string };
+export interface AuthnMethodSecuritySettings {
+  'protection' : AuthnMethodProtection,
+  'purpose' : AuthnMethodPurpose,
+}
+export type AuthnMethodSecuritySettingsReplaceError = {
+    'AuthnMethodNotFound' : null
+  };
+export interface BufferedArchiveEntry {
+  'sequence_number' : bigint,
+  'entry' : Uint8Array | number[],
+  'anchor_number' : UserNumber,
+  'timestamp' : Timestamp,
+}
+export type CaptchaResult = ChallengeResult;
+export interface Challenge {
+  'png_base64' : string,
+  'challenge_key' : ChallengeKey,
+}
+export type ChallengeKey = string;
+export interface ChallengeResult { 'key' : ChallengeKey, 'chars' : string }
+export type CredentialId = Uint8Array | number[];
+export interface Delegation {
+  'pubkey' : PublicKey,
+  'targets' : [] | [Array<Principal>],
+  'expiration' : Timestamp,
+}
+export type DeployArchiveResult = { 'creation_in_progress' : null } |
+  { 'success' : Principal } |
+  { 'failed' : string };
+export interface DeviceData {
+  'alias' : string,
+  'metadata' : [] | [MetadataMap],
+  'origin' : [] | [string],
+  'protection' : DeviceProtection,
+  'pubkey' : DeviceKey,
+  'key_type' : KeyType,
+  'purpose' : Purpose,
+  'credential_id' : [] | [CredentialId],
+}
+export type DeviceKey = PublicKey;
+export type DeviceProtection = { 'unprotected' : null } |
+  { 'protected' : null };
+export interface DeviceRegistrationInfo {
+  'tentative_device' : [] | [DeviceData],
+  'expiration' : Timestamp,
+}
+export interface DeviceWithUsage {
+  'alias' : string,
+  'last_usage' : [] | [Timestamp],
+  'metadata' : [] | [MetadataMap],
+  'origin' : [] | [string],
+  'protection' : DeviceProtection,
+  'pubkey' : DeviceKey,
+  'key_type' : KeyType,
+  'purpose' : Purpose,
+  'credential_id' : [] | [CredentialId],
+}
+export type FrontendHostname = string;
+export type GetDelegationResponse = { 'no_such_delegation' : null } |
+  { 'signed_delegation' : SignedDelegation };
+export type GetIdAliasError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal } |
+  { 'NoSuchCredentials' : string };
+export interface GetIdAliasRequest {
+  'rp_id_alias_jwt' : string,
+  'issuer' : FrontendHostname,
+  'issuer_id_alias_jwt' : string,
+  'relying_party' : FrontendHostname,
+  'identity_number' : IdentityNumber,
+}
+export type HeaderField = [string, string];
+export interface HttpRequest {
+  'url' : string,
+  'method' : string,
+  'body' : Uint8Array | number[],
+  'headers' : Array<HeaderField>,
+  'certificate_version' : [] | [number],
+}
+export interface HttpResponse {
+  'body' : Uint8Array | number[],
+  'headers' : Array<HeaderField>,
+  'upgrade' : [] | [boolean],
+  'streaming_strategy' : [] | [StreamingStrategy],
+  'status_code' : number,
+}
+export interface IdAliasCredentials {
+  'rp_id_alias_credential' : SignedIdAlias,
+  'issuer_id_alias_credential' : SignedIdAlias,
+}
+export interface IdentityAnchorInfo {
+  'devices' : Array<DeviceWithUsage>,
+  'device_registration' : [] | [DeviceRegistrationInfo],
+}
+export interface IdentityAuthnInfo {
+  'authn_methods' : Array<AuthnMethod>,
+  'recovery_authn_methods' : Array<AuthnMethod>,
+}
+export interface IdentityInfo {
+  'authn_methods' : Array<AuthnMethodData>,
+  'metadata' : MetadataMapV2,
+  'authn_method_registration' : [] | [AuthnMethodRegistrationInfo],
+}
+export type IdentityInfoError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal };
+export type IdentityMetadataReplaceError = {
+    'InternalCanisterError' : string
+  } |
+  { 'Unauthorized' : Principal } |
+  {
+    'StorageSpaceExceeded' : {
+      'space_required' : bigint,
+      'space_available' : bigint,
+    }
+  };
+export type IdentityNumber = bigint;
+export type IdentityRegisterError = { 'BadCaptcha' : null } |
+  { 'CanisterFull' : null } |
+  { 'InvalidMetadata' : string };
+export interface InternetIdentityInit {
+  'max_num_latest_delegation_origins' : [] | [bigint],
+  'assigned_user_number_range' : [] | [[bigint, bigint]],
+  'max_inflight_captchas' : [] | [bigint],
+  'archive_config' : [] | [ArchiveConfig],
+  'canister_creation_cycles_cost' : [] | [bigint],
+  'register_rate_limit' : [] | [RateLimitConfig],
+}
+export interface InternetIdentityStats {
+  'storage_layout_version' : number,
+  'users_registered' : bigint,
+  'max_num_latest_delegation_origins' : bigint,
+  'assigned_user_number_range' : [bigint, bigint],
+  'latest_delegation_origins' : Array<FrontendHostname>,
+  'archive_info' : ArchiveInfo,
+  'canister_creation_cycles_cost' : bigint,
+}
+export type KeyType = { 'platform' : null } |
+  { 'seed_phrase' : null } |
+  { 'cross_platform' : null } |
+  { 'unknown' : null } |
+  { 'browser_storage_key' : null };
+export type MetadataMap = Array<
+  [
+    string,
+    { 'map' : MetadataMap } |
+      { 'string' : string } |
+      { 'bytes' : Uint8Array | number[] },
+  ]
+>;
+export type MetadataMapV2 = Array<
+  [
+    string,
+    { 'Map' : MetadataMapV2 } |
+      { 'String' : string } |
+      { 'Bytes' : Uint8Array | number[] },
+  ]
+>;
+export type PrepareIdAliasError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal };
+export interface PrepareIdAliasRequest {
+  'issuer' : FrontendHostname,
+  'relying_party' : FrontendHostname,
+  'identity_number' : IdentityNumber,
+}
+export interface PreparedIdAlias {
+  'rp_id_alias_jwt' : string,
+  'issuer_id_alias_jwt' : string,
+  'canister_sig_pk_der' : PublicKey,
+}
+export type PublicKey = Uint8Array | number[];
+export interface PublicKeyAuthn { 'pubkey' : PublicKey }
+export type Purpose = { 'authentication' : null } |
+  { 'recovery' : null };
+export interface RateLimitConfig {
+  'max_tokens' : bigint,
+  'time_per_token_ns' : bigint,
+}
+export type RegisterResponse = { 'bad_challenge' : null } |
+  { 'canister_full' : null } |
+  { 'registered' : { 'user_number' : UserNumber } };
+export type SessionKey = PublicKey;
+export interface SignedDelegation {
+  'signature' : Uint8Array | number[],
+  'delegation' : Delegation,
+}
+export interface SignedIdAlias {
+  'credential_jws' : string,
+  'id_alias' : Principal,
+  'id_dapp' : Principal,
+}
+export interface StreamingCallbackHttpResponse {
+  'token' : [] | [Token],
+  'body' : Uint8Array | number[],
+}
+export type StreamingStrategy = {
+    'Callback' : { 'token' : Token, 'callback' : [Principal, string] }
+  };
+export type Timestamp = bigint;
+export type Token = {};
+export type UserKey = PublicKey;
+export type UserNumber = bigint;
+export type VerifyTentativeDeviceResponse = {
+    'device_registration_mode_off' : null
+  } |
+  { 'verified' : null } |
+  { 'wrong_code' : { 'retries_left' : number } } |
+  { 'no_device_to_verify' : null };
+export interface WebAuthn {
+  'pubkey' : PublicKey,
+  'credential_id' : CredentialId,
+}
+export interface WebAuthnCredential {
+  'pubkey' : PublicKey,
+  'credential_id' : CredentialId,
+}
+export interface _SERVICE {
+  'acknowledge_entries' : ActorMethod<[bigint], undefined>,
+  'add' : ActorMethod<[UserNumber, DeviceData], undefined>,
+  'add_tentative_device' : ActorMethod<
+    [UserNumber, DeviceData],
+    AddTentativeDeviceResponse
+  >,
+  'authn_method_add' : ActorMethod<
+    [IdentityNumber, AuthnMethodData],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodAddError }
+  >,
+  'authn_method_confirm' : ActorMethod<
+    [IdentityNumber, string],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodConfirmationError }
+  >,
+  'authn_method_metadata_replace' : ActorMethod<
+    [IdentityNumber, PublicKey, MetadataMapV2],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodMetadataReplaceError }
+  >,
+  'authn_method_register' : ActorMethod<
+    [IdentityNumber, AuthnMethodData],
+    { 'Ok' : AuthnMethodConfirmationCode } |
+      { 'Err' : AuthnMethodRegisterError }
+  >,
+  'authn_method_registration_mode_enter' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : { 'expiration' : Timestamp } } |
+      { 'Err' : null }
+  >,
+  'authn_method_registration_mode_exit' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : null } |
+      { 'Err' : null }
+  >,
+  'authn_method_remove' : ActorMethod<
+    [IdentityNumber, PublicKey],
+    { 'Ok' : null } |
+      { 'Err' : null }
+  >,
+  'authn_method_replace' : ActorMethod<
+    [IdentityNumber, PublicKey, AuthnMethodData],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodReplaceError }
+  >,
+  'authn_method_security_settings_replace' : ActorMethod<
+    [IdentityNumber, PublicKey, AuthnMethodSecuritySettings],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodSecuritySettingsReplaceError }
+  >,
+  'captcha_create' : ActorMethod<[], { 'Ok' : Challenge } | { 'Err' : null }>,
+  'create_challenge' : ActorMethod<[], Challenge>,
+  'deploy_archive' : ActorMethod<[Uint8Array | number[]], DeployArchiveResult>,
+  'enter_device_registration_mode' : ActorMethod<[UserNumber], Timestamp>,
+  'exit_device_registration_mode' : ActorMethod<[UserNumber], undefined>,
+  'fetch_entries' : ActorMethod<[], Array<BufferedArchiveEntry>>,
+  'get_anchor_credentials' : ActorMethod<[UserNumber], AnchorCredentials>,
+  'get_anchor_info' : ActorMethod<[UserNumber], IdentityAnchorInfo>,
+  'get_delegation' : ActorMethod<
+    [UserNumber, FrontendHostname, SessionKey, Timestamp],
+    GetDelegationResponse
+  >,
+  'get_id_alias' : ActorMethod<
+    [GetIdAliasRequest],
+    { 'Ok' : IdAliasCredentials } |
+      { 'Err' : GetIdAliasError }
+  >,
+  'get_principal' : ActorMethod<[UserNumber, FrontendHostname], Principal>,
+  'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  'http_request_update' : ActorMethod<[HttpRequest], HttpResponse>,
+  'identity_authn_info' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : IdentityAuthnInfo } |
+      { 'Err' : null }
+  >,
+  'identity_info' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : IdentityInfo } |
+      { 'Err' : IdentityInfoError }
+  >,
+  'identity_metadata_replace' : ActorMethod<
+    [IdentityNumber, MetadataMapV2],
+    { 'Ok' : null } |
+      { 'Err' : IdentityMetadataReplaceError }
+  >,
+  'identity_register' : ActorMethod<
+    [AuthnMethodData, CaptchaResult, [] | [Principal]],
+    { 'Ok' : IdentityNumber } |
+      { 'Err' : IdentityRegisterError }
+  >,
+  'init_salt' : ActorMethod<[], undefined>,
+  'lookup' : ActorMethod<[UserNumber], Array<DeviceData>>,
+  'prepare_delegation' : ActorMethod<
+    [UserNumber, FrontendHostname, SessionKey, [] | [bigint]],
+    [UserKey, Timestamp]
+  >,
+  'prepare_id_alias' : ActorMethod<
+    [PrepareIdAliasRequest],
+    { 'Ok' : PreparedIdAlias } |
+      { 'Err' : PrepareIdAliasError }
+  >,
+  'register' : ActorMethod<
+    [DeviceData, ChallengeResult, [] | [Principal]],
+    RegisterResponse
+  >,
+  'remove' : ActorMethod<[UserNumber, DeviceKey], undefined>,
+  'replace' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
+  'stats' : ActorMethod<[], InternetIdentityStats>,
+  'update' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
+  'verify_tentative_device' : ActorMethod<
+    [UserNumber, string],
+    VerifyTentativeDeviceResponse
+  >,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/internet_identity/internet_identity.did.js
+++ b/src/declarations/internet_identity/internet_identity.did.js
@@ -1,0 +1,506 @@
+export const idlFactory = ({ IDL }) => {
+  const MetadataMap = IDL.Rec();
+  const MetadataMapV2 = IDL.Rec();
+  const ArchiveConfig = IDL.Record({
+    'polling_interval_ns' : IDL.Nat64,
+    'entries_buffer_limit' : IDL.Nat64,
+    'module_hash' : IDL.Vec(IDL.Nat8),
+    'entries_fetch_limit' : IDL.Nat16,
+  });
+  const RateLimitConfig = IDL.Record({
+    'max_tokens' : IDL.Nat64,
+    'time_per_token_ns' : IDL.Nat64,
+  });
+  const InternetIdentityInit = IDL.Record({
+    'max_num_latest_delegation_origins' : IDL.Opt(IDL.Nat64),
+    'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
+    'max_inflight_captchas' : IDL.Opt(IDL.Nat64),
+    'archive_config' : IDL.Opt(ArchiveConfig),
+    'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'register_rate_limit' : IDL.Opt(RateLimitConfig),
+  });
+  const UserNumber = IDL.Nat64;
+  MetadataMap.fill(
+    IDL.Vec(
+      IDL.Tuple(
+        IDL.Text,
+        IDL.Variant({
+          'map' : MetadataMap,
+          'string' : IDL.Text,
+          'bytes' : IDL.Vec(IDL.Nat8),
+        }),
+      )
+    )
+  );
+  const DeviceProtection = IDL.Variant({
+    'unprotected' : IDL.Null,
+    'protected' : IDL.Null,
+  });
+  const PublicKey = IDL.Vec(IDL.Nat8);
+  const DeviceKey = PublicKey;
+  const KeyType = IDL.Variant({
+    'platform' : IDL.Null,
+    'seed_phrase' : IDL.Null,
+    'cross_platform' : IDL.Null,
+    'unknown' : IDL.Null,
+    'browser_storage_key' : IDL.Null,
+  });
+  const Purpose = IDL.Variant({
+    'authentication' : IDL.Null,
+    'recovery' : IDL.Null,
+  });
+  const CredentialId = IDL.Vec(IDL.Nat8);
+  const DeviceData = IDL.Record({
+    'alias' : IDL.Text,
+    'metadata' : IDL.Opt(MetadataMap),
+    'origin' : IDL.Opt(IDL.Text),
+    'protection' : DeviceProtection,
+    'pubkey' : DeviceKey,
+    'key_type' : KeyType,
+    'purpose' : Purpose,
+    'credential_id' : IDL.Opt(CredentialId),
+  });
+  const Timestamp = IDL.Nat64;
+  const AddTentativeDeviceResponse = IDL.Variant({
+    'device_registration_mode_off' : IDL.Null,
+    'another_device_tentatively_added' : IDL.Null,
+    'added_tentatively' : IDL.Record({
+      'verification_code' : IDL.Text,
+      'device_registration_timeout' : Timestamp,
+    }),
+  });
+  const IdentityNumber = IDL.Nat64;
+  const AuthnMethodProtection = IDL.Variant({
+    'Protected' : IDL.Null,
+    'Unprotected' : IDL.Null,
+  });
+  const AuthnMethodPurpose = IDL.Variant({
+    'Recovery' : IDL.Null,
+    'Authentication' : IDL.Null,
+  });
+  const AuthnMethodSecuritySettings = IDL.Record({
+    'protection' : AuthnMethodProtection,
+    'purpose' : AuthnMethodPurpose,
+  });
+  MetadataMapV2.fill(
+    IDL.Vec(
+      IDL.Tuple(
+        IDL.Text,
+        IDL.Variant({
+          'Map' : MetadataMapV2,
+          'String' : IDL.Text,
+          'Bytes' : IDL.Vec(IDL.Nat8),
+        }),
+      )
+    )
+  );
+  const PublicKeyAuthn = IDL.Record({ 'pubkey' : PublicKey });
+  const WebAuthn = IDL.Record({
+    'pubkey' : PublicKey,
+    'credential_id' : CredentialId,
+  });
+  const AuthnMethod = IDL.Variant({
+    'PubKey' : PublicKeyAuthn,
+    'WebAuthn' : WebAuthn,
+  });
+  const AuthnMethodData = IDL.Record({
+    'security_settings' : AuthnMethodSecuritySettings,
+    'metadata' : MetadataMapV2,
+    'last_authentication' : IDL.Opt(Timestamp),
+    'authn_method' : AuthnMethod,
+  });
+  const AuthnMethodAddError = IDL.Variant({ 'InvalidMetadata' : IDL.Text });
+  const AuthnMethodConfirmationError = IDL.Variant({
+    'RegistrationModeOff' : IDL.Null,
+    'NoAuthnMethodToConfirm' : IDL.Null,
+    'WrongCode' : IDL.Record({ 'retries_left' : IDL.Nat8 }),
+  });
+  const AuthnMethodMetadataReplaceError = IDL.Variant({
+    'AuthnMethodNotFound' : IDL.Null,
+    'InvalidMetadata' : IDL.Text,
+  });
+  const AuthnMethodConfirmationCode = IDL.Record({
+    'confirmation_code' : IDL.Text,
+    'expiration' : Timestamp,
+  });
+  const AuthnMethodRegisterError = IDL.Variant({
+    'RegistrationModeOff' : IDL.Null,
+    'RegistrationAlreadyInProgress' : IDL.Null,
+    'InvalidMetadata' : IDL.Text,
+  });
+  const AuthnMethodReplaceError = IDL.Variant({
+    'AuthnMethodNotFound' : IDL.Null,
+    'InvalidMetadata' : IDL.Text,
+  });
+  const AuthnMethodSecuritySettingsReplaceError = IDL.Variant({
+    'AuthnMethodNotFound' : IDL.Null,
+  });
+  const ChallengeKey = IDL.Text;
+  const Challenge = IDL.Record({
+    'png_base64' : IDL.Text,
+    'challenge_key' : ChallengeKey,
+  });
+  const DeployArchiveResult = IDL.Variant({
+    'creation_in_progress' : IDL.Null,
+    'success' : IDL.Principal,
+    'failed' : IDL.Text,
+  });
+  const BufferedArchiveEntry = IDL.Record({
+    'sequence_number' : IDL.Nat64,
+    'entry' : IDL.Vec(IDL.Nat8),
+    'anchor_number' : UserNumber,
+    'timestamp' : Timestamp,
+  });
+  const WebAuthnCredential = IDL.Record({
+    'pubkey' : PublicKey,
+    'credential_id' : CredentialId,
+  });
+  const AnchorCredentials = IDL.Record({
+    'recovery_phrases' : IDL.Vec(PublicKey),
+    'credentials' : IDL.Vec(WebAuthnCredential),
+    'recovery_credentials' : IDL.Vec(WebAuthnCredential),
+  });
+  const DeviceWithUsage = IDL.Record({
+    'alias' : IDL.Text,
+    'last_usage' : IDL.Opt(Timestamp),
+    'metadata' : IDL.Opt(MetadataMap),
+    'origin' : IDL.Opt(IDL.Text),
+    'protection' : DeviceProtection,
+    'pubkey' : DeviceKey,
+    'key_type' : KeyType,
+    'purpose' : Purpose,
+    'credential_id' : IDL.Opt(CredentialId),
+  });
+  const DeviceRegistrationInfo = IDL.Record({
+    'tentative_device' : IDL.Opt(DeviceData),
+    'expiration' : Timestamp,
+  });
+  const IdentityAnchorInfo = IDL.Record({
+    'devices' : IDL.Vec(DeviceWithUsage),
+    'device_registration' : IDL.Opt(DeviceRegistrationInfo),
+  });
+  const FrontendHostname = IDL.Text;
+  const SessionKey = PublicKey;
+  const Delegation = IDL.Record({
+    'pubkey' : PublicKey,
+    'targets' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'expiration' : Timestamp,
+  });
+  const SignedDelegation = IDL.Record({
+    'signature' : IDL.Vec(IDL.Nat8),
+    'delegation' : Delegation,
+  });
+  const GetDelegationResponse = IDL.Variant({
+    'no_such_delegation' : IDL.Null,
+    'signed_delegation' : SignedDelegation,
+  });
+  const GetIdAliasRequest = IDL.Record({
+    'rp_id_alias_jwt' : IDL.Text,
+    'issuer' : FrontendHostname,
+    'issuer_id_alias_jwt' : IDL.Text,
+    'relying_party' : FrontendHostname,
+    'identity_number' : IdentityNumber,
+  });
+  const SignedIdAlias = IDL.Record({
+    'credential_jws' : IDL.Text,
+    'id_alias' : IDL.Principal,
+    'id_dapp' : IDL.Principal,
+  });
+  const IdAliasCredentials = IDL.Record({
+    'rp_id_alias_credential' : SignedIdAlias,
+    'issuer_id_alias_credential' : SignedIdAlias,
+  });
+  const GetIdAliasError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+    'NoSuchCredentials' : IDL.Text,
+  });
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'certificate_version' : IDL.Opt(IDL.Nat16),
+  });
+  const Token = IDL.Record({});
+  const StreamingCallbackHttpResponse = IDL.Record({
+    'token' : IDL.Opt(Token),
+    'body' : IDL.Vec(IDL.Nat8),
+  });
+  const StreamingStrategy = IDL.Variant({
+    'Callback' : IDL.Record({
+      'token' : Token,
+      'callback' : IDL.Func(
+          [Token],
+          [StreamingCallbackHttpResponse],
+          ['query'],
+        ),
+    }),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'upgrade' : IDL.Opt(IDL.Bool),
+    'streaming_strategy' : IDL.Opt(StreamingStrategy),
+    'status_code' : IDL.Nat16,
+  });
+  const IdentityAuthnInfo = IDL.Record({
+    'authn_methods' : IDL.Vec(AuthnMethod),
+    'recovery_authn_methods' : IDL.Vec(AuthnMethod),
+  });
+  const AuthnMethodRegistrationInfo = IDL.Record({
+    'expiration' : Timestamp,
+    'authn_method' : IDL.Opt(AuthnMethodData),
+  });
+  const IdentityInfo = IDL.Record({
+    'authn_methods' : IDL.Vec(AuthnMethodData),
+    'metadata' : MetadataMapV2,
+    'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
+  });
+  const IdentityInfoError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+  });
+  const IdentityMetadataReplaceError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+    'StorageSpaceExceeded' : IDL.Record({
+      'space_required' : IDL.Nat64,
+      'space_available' : IDL.Nat64,
+    }),
+  });
+  const ChallengeResult = IDL.Record({
+    'key' : ChallengeKey,
+    'chars' : IDL.Text,
+  });
+  const CaptchaResult = ChallengeResult;
+  const IdentityRegisterError = IDL.Variant({
+    'BadCaptcha' : IDL.Null,
+    'CanisterFull' : IDL.Null,
+    'InvalidMetadata' : IDL.Text,
+  });
+  const UserKey = PublicKey;
+  const PrepareIdAliasRequest = IDL.Record({
+    'issuer' : FrontendHostname,
+    'relying_party' : FrontendHostname,
+    'identity_number' : IdentityNumber,
+  });
+  const PreparedIdAlias = IDL.Record({
+    'rp_id_alias_jwt' : IDL.Text,
+    'issuer_id_alias_jwt' : IDL.Text,
+    'canister_sig_pk_der' : PublicKey,
+  });
+  const PrepareIdAliasError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+  });
+  const RegisterResponse = IDL.Variant({
+    'bad_challenge' : IDL.Null,
+    'canister_full' : IDL.Null,
+    'registered' : IDL.Record({ 'user_number' : UserNumber }),
+  });
+  const ArchiveInfo = IDL.Record({
+    'archive_config' : IDL.Opt(ArchiveConfig),
+    'archive_canister' : IDL.Opt(IDL.Principal),
+  });
+  const InternetIdentityStats = IDL.Record({
+    'storage_layout_version' : IDL.Nat8,
+    'users_registered' : IDL.Nat64,
+    'max_num_latest_delegation_origins' : IDL.Nat64,
+    'assigned_user_number_range' : IDL.Tuple(IDL.Nat64, IDL.Nat64),
+    'latest_delegation_origins' : IDL.Vec(FrontendHostname),
+    'archive_info' : ArchiveInfo,
+    'canister_creation_cycles_cost' : IDL.Nat64,
+  });
+  const VerifyTentativeDeviceResponse = IDL.Variant({
+    'device_registration_mode_off' : IDL.Null,
+    'verified' : IDL.Null,
+    'wrong_code' : IDL.Record({ 'retries_left' : IDL.Nat8 }),
+    'no_device_to_verify' : IDL.Null,
+  });
+  return IDL.Service({
+    'acknowledge_entries' : IDL.Func([IDL.Nat64], [], []),
+    'add' : IDL.Func([UserNumber, DeviceData], [], []),
+    'add_tentative_device' : IDL.Func(
+        [UserNumber, DeviceData],
+        [AddTentativeDeviceResponse],
+        [],
+      ),
+    'authn_method_add' : IDL.Func(
+        [IdentityNumber, AuthnMethodData],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : AuthnMethodAddError })],
+        [],
+      ),
+    'authn_method_confirm' : IDL.Func(
+        [IdentityNumber, IDL.Text],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Null,
+            'Err' : AuthnMethodConfirmationError,
+          }),
+        ],
+        [],
+      ),
+    'authn_method_metadata_replace' : IDL.Func(
+        [IdentityNumber, PublicKey, MetadataMapV2],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Null,
+            'Err' : AuthnMethodMetadataReplaceError,
+          }),
+        ],
+        [],
+      ),
+    'authn_method_register' : IDL.Func(
+        [IdentityNumber, AuthnMethodData],
+        [
+          IDL.Variant({
+            'Ok' : AuthnMethodConfirmationCode,
+            'Err' : AuthnMethodRegisterError,
+          }),
+        ],
+        [],
+      ),
+    'authn_method_registration_mode_enter' : IDL.Func(
+        [IdentityNumber],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Record({ 'expiration' : Timestamp }),
+            'Err' : IDL.Null,
+          }),
+        ],
+        [],
+      ),
+    'authn_method_registration_mode_exit' : IDL.Func(
+        [IdentityNumber],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Null })],
+        [],
+      ),
+    'authn_method_remove' : IDL.Func(
+        [IdentityNumber, PublicKey],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Null })],
+        [],
+      ),
+    'authn_method_replace' : IDL.Func(
+        [IdentityNumber, PublicKey, AuthnMethodData],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : AuthnMethodReplaceError })],
+        [],
+      ),
+    'authn_method_security_settings_replace' : IDL.Func(
+        [IdentityNumber, PublicKey, AuthnMethodSecuritySettings],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Null,
+            'Err' : AuthnMethodSecuritySettingsReplaceError,
+          }),
+        ],
+        [],
+      ),
+    'captcha_create' : IDL.Func(
+        [],
+        [IDL.Variant({ 'Ok' : Challenge, 'Err' : IDL.Null })],
+        [],
+      ),
+    'create_challenge' : IDL.Func([], [Challenge], []),
+    'deploy_archive' : IDL.Func([IDL.Vec(IDL.Nat8)], [DeployArchiveResult], []),
+    'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),
+    'exit_device_registration_mode' : IDL.Func([UserNumber], [], []),
+    'fetch_entries' : IDL.Func([], [IDL.Vec(BufferedArchiveEntry)], []),
+    'get_anchor_credentials' : IDL.Func(
+        [UserNumber],
+        [AnchorCredentials],
+        ['query'],
+      ),
+    'get_anchor_info' : IDL.Func([UserNumber], [IdentityAnchorInfo], []),
+    'get_delegation' : IDL.Func(
+        [UserNumber, FrontendHostname, SessionKey, Timestamp],
+        [GetDelegationResponse],
+        ['query'],
+      ),
+    'get_id_alias' : IDL.Func(
+        [GetIdAliasRequest],
+        [IDL.Variant({ 'Ok' : IdAliasCredentials, 'Err' : GetIdAliasError })],
+        ['query'],
+      ),
+    'get_principal' : IDL.Func(
+        [UserNumber, FrontendHostname],
+        [IDL.Principal],
+        ['query'],
+      ),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'http_request_update' : IDL.Func([HttpRequest], [HttpResponse], []),
+    'identity_authn_info' : IDL.Func(
+        [IdentityNumber],
+        [IDL.Variant({ 'Ok' : IdentityAuthnInfo, 'Err' : IDL.Null })],
+        ['query'],
+      ),
+    'identity_info' : IDL.Func(
+        [IdentityNumber],
+        [IDL.Variant({ 'Ok' : IdentityInfo, 'Err' : IdentityInfoError })],
+        [],
+      ),
+    'identity_metadata_replace' : IDL.Func(
+        [IdentityNumber, MetadataMapV2],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Null,
+            'Err' : IdentityMetadataReplaceError,
+          }),
+        ],
+        [],
+      ),
+    'identity_register' : IDL.Func(
+        [AuthnMethodData, CaptchaResult, IDL.Opt(IDL.Principal)],
+        [IDL.Variant({ 'Ok' : IdentityNumber, 'Err' : IdentityRegisterError })],
+        [],
+      ),
+    'init_salt' : IDL.Func([], [], []),
+    'lookup' : IDL.Func([UserNumber], [IDL.Vec(DeviceData)], ['query']),
+    'prepare_delegation' : IDL.Func(
+        [UserNumber, FrontendHostname, SessionKey, IDL.Opt(IDL.Nat64)],
+        [UserKey, Timestamp],
+        [],
+      ),
+    'prepare_id_alias' : IDL.Func(
+        [PrepareIdAliasRequest],
+        [IDL.Variant({ 'Ok' : PreparedIdAlias, 'Err' : PrepareIdAliasError })],
+        [],
+      ),
+    'register' : IDL.Func(
+        [DeviceData, ChallengeResult, IDL.Opt(IDL.Principal)],
+        [RegisterResponse],
+        [],
+      ),
+    'remove' : IDL.Func([UserNumber, DeviceKey], [], []),
+    'replace' : IDL.Func([UserNumber, DeviceKey, DeviceData], [], []),
+    'stats' : IDL.Func([], [InternetIdentityStats], ['query']),
+    'update' : IDL.Func([UserNumber, DeviceKey, DeviceData], [], []),
+    'verify_tentative_device' : IDL.Func(
+        [UserNumber, IDL.Text],
+        [VerifyTentativeDeviceResponse],
+        [],
+      ),
+  });
+};
+export const init = ({ IDL }) => {
+  const ArchiveConfig = IDL.Record({
+    'polling_interval_ns' : IDL.Nat64,
+    'entries_buffer_limit' : IDL.Nat64,
+    'module_hash' : IDL.Vec(IDL.Nat8),
+    'entries_fetch_limit' : IDL.Nat16,
+  });
+  const RateLimitConfig = IDL.Record({
+    'max_tokens' : IDL.Nat64,
+    'time_per_token_ns' : IDL.Nat64,
+  });
+  const InternetIdentityInit = IDL.Record({
+    'max_num_latest_delegation_origins' : IDL.Opt(IDL.Nat64),
+    'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
+    'max_inflight_captchas' : IDL.Opt(IDL.Nat64),
+    'archive_config' : IDL.Opt(ArchiveConfig),
+    'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'register_rate_limit' : IDL.Opt(RateLimitConfig),
+  });
+  return [IDL.Opt(InternetIdentityInit)];
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,7 @@ const canisterDefinitions = Object.entries(canisterIds).reduce(
   (acc, [key, val]) => ({
     ...acc,
     [`process.env.${key.toUpperCase()}_CANISTER_ID`]: JSON.stringify(val[networkName]),
+    [`process.env.CANISTER_ID_${key.toUpperCase()}`]: JSON.stringify(val[networkName]),
   }),
   {},
 );


### PR DESCRIPTION
Adds in-browser vector database as local RAG
Adds functionality to store and retrieve vectors (hidden from UI for now)
Changes caching strategy to StaleWhileRevalidate
Upgrades WebLLM dependency
Adds new models: desktop (Phi3-mini, WizardMath-7B, Hermes-2-Pro, Qwen1.5, stablelm-2-zephyr), Android (Phi3)
Removes non-working models
Makes PWA easier to install and functionality more discoverable