### PR TITLE
Keep last 5 messages as model input

### DIFF
--- a/src/DeVinci_frontend/components/ChatBox.svelte
+++ b/src/DeVinci_frontend/components/ChatBox.svelte
@@ -61,8 +61,7 @@
       newMessageText = '';
       try {
         messages = [...messages, { role: 'assistant', content: replyText, name: 'DeVinci' }];
-        const promptFormattedForModel = [newMessageEntry]; // passing in the message history easily overwhelms the available device memory --> TODO: find good way to keep memory (as currently each message is like a new chat without the LLM knowing about any messages before)
-        const reply = await modelCallbackFunction(promptFormattedForModel, generateProgressCallback);
+        const reply = await modelCallbackFunction(messageHistoryWithPrompt.slice(-5), generateProgressCallback); // passing in much of the message history easily overwhelms the available device memory
         messages = [...messages.slice(0, -1), { role: 'assistant', content: reply, name: 'DeVinci' }]; 
       } catch (error) {
         console.error("Error getting response from model: ", error);


### PR DESCRIPTION
This adds some memory of the previous messages in the chat to the model (last 5 messages as the device and context window can easily be overwhelmed with too much content).